### PR TITLE
Add efk HA templates

### DIFF
--- a/feature-demos/logging/efk/logging/efk-ha-stack/README.md
+++ b/feature-demos/logging/efk/logging/efk-ha-stack/README.md
@@ -1,0 +1,38 @@
+# EFK HA SETUP
+
+* The contents of this directory is taken from https://github.com/pires/kubernetes-elasticsearch-cluster 
+* I really appreciate the work of pires which has already saved a lot of time and work.
+* I have tested this on GKE.
+* The prerequisits given below is the minimum hardware requirement, Please refer to the link given above for more details.
+* As this is just an demo setup, so i'm using emptydir, you should use any persistent storage such as openebs.
+
+## Prerequisits :
+
+- Min 3 nodes with min 8 cpu and 20 gb storage.
+
+## How to deploy :
+**Note** : Please run the following in the order
+
+- Run `git clone https://github.com/openebs/community.git`
+- change directory to `logging/efk-ha-setup/`
+- Run `kubectl create ns logging`
+- Run `kubectl create -f es-discovery-svc.yaml`
+- Run `kubectl create -f es-svc.yaml`
+- Run `kubectl create -f es-master.yaml`
+- Run `kubectl rollout status -f es-master.yaml`
+- Run `kubectl create -f es-client.yaml`
+- Run `kubectl rollout status -f es-client.yaml`
+- Run `kubectl create -f es-data.yaml`
+- Run `kubectl rollout status -f es-data.yaml`
+- Run `kubectl create -f fluentd-config.yaml`
+- Run `kubectl create -f fluentd.yaml`
+- Run `kubectl create -f kibana.yaml`
+- Wait for atleast 5-10 mins to let the whole setup configured properly.
+- Run `kubectl get svc -n=logging` and note down the NodePort (30560) and open
+  the kibana UI in browser. (NodeIP:NodePort)
+- Run `kubectl create -f openebs-operator.yaml`
+- Open the discover tab in kibana ui and type `logstash-*` in the index-pattern 
+- field and then choose `@timestamp` and click `create index pattern`.
+- Now click on the `logstash-*` in the index pattern and then on discover tab, you
+  should be able to get the logs there.
+   

--- a/feature-demos/logging/efk/logging/efk-ha-stack/es-client.yaml
+++ b/feature-demos/logging/efk/logging/efk-ha-stack/es-client.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: es-client
+  namespace: logging
+  labels:
+    component: elasticsearch
+    role: client
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        component: elasticsearch
+        role: client
+    spec:
+      initContainers:
+      - name: init-sysctl
+        image: busybox:1.27.2
+        command:
+        - sysctl
+        - -w
+        - vm.max_map_count=262144
+        securityContext:
+          privileged: true
+      containers:
+      - name: es-client
+        image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.2
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: CLUSTER_NAME
+          value: myesdb
+        - name: NODE_MASTER
+          value: "false"
+        - name: NODE_DATA
+          value: "false"
+        - name: HTTP_ENABLE
+          value: "true"
+        - name: ES_JAVA_OPTS
+          value: -Xms256m -Xmx256m
+        - name: NETWORK_HOST
+          value: _site_,_lo_
+        - name: PROCESSORS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        resources:
+          limits:
+            cpu: 1
+        ports:
+        - containerPort: 9200
+          name: http
+        - containerPort: 9300
+          name: transport
+        livenessProbe:
+          tcpSocket:
+            port: transport
+        readinessProbe:
+          httpGet:
+            path: /_cluster/health
+            port: http
+          initialDelaySeconds: 20
+          timeoutSeconds: 5
+        volumeMounts:
+        - name: storage
+          mountPath: /data
+      volumes:
+          - emptyDir:
+              medium: ""
+            name: storage

--- a/feature-demos/logging/efk/logging/efk-ha-stack/es-data.yaml
+++ b/feature-demos/logging/efk/logging/efk-ha-stack/es-data.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: es-data
+  namespace: logging
+  labels:
+    component: elasticsearch
+    role: data
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        component: elasticsearch
+        role: data
+    spec:
+      initContainers:
+      - name: init-sysctl
+        image: busybox:1.27.2
+        command:
+        - sysctl
+        - -w
+        - vm.max_map_count=262144
+        securityContext:
+          privileged: true
+      containers:
+      - name: es-data
+        image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.2
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: CLUSTER_NAME
+          value: myesdb
+        - name: NODE_MASTER
+          value: "false"
+        - name: NODE_INGEST
+          value: "false"
+        - name: HTTP_ENABLE
+          value: "false"
+        - name: ES_JAVA_OPTS
+          value: -Xms256m -Xmx256m
+        - name: PROCESSORS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        resources:
+          limits:
+            cpu: 1
+        ports:
+        - containerPort: 9300
+          name: transport
+        livenessProbe:
+          tcpSocket:
+            port: transport
+          initialDelaySeconds: 20
+          periodSeconds: 10
+        volumeMounts:
+        - name: storage
+          mountPath: /data
+      volumes:
+          - emptyDir:
+              medium: ""
+            name: storage

--- a/feature-demos/logging/efk/logging/efk-ha-stack/es-discovery-svc.yaml
+++ b/feature-demos/logging/efk/logging/efk-ha-stack/es-discovery-svc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch-discovery
+  namespace: logging
+  labels:
+    component: elasticsearch
+    role: master
+spec:
+  selector:
+    component: elasticsearch
+    role: master
+  ports:
+  - name: transport
+    port: 9300
+    protocol: TCP

--- a/feature-demos/logging/efk/logging/efk-ha-stack/es-master.yaml
+++ b/feature-demos/logging/efk/logging/efk-ha-stack/es-master.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: es-master
+  namespace: logging
+  labels:
+    component: elasticsearch
+    role: master
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        component: elasticsearch
+        role: master
+    spec:
+      initContainers:
+      - name: init-sysctl
+        image: busybox:1.27.2
+        command:
+        - sysctl
+        - -w
+        - vm.max_map_count=262144
+        securityContext:
+          privileged: true
+      containers:
+      - name: es-master
+        image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.2
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: CLUSTER_NAME
+          value: myesdb
+        - name: NUMBER_OF_MASTERS
+          value: "1"
+        - name: NODE_MASTER
+          value: "true"
+        - name: NODE_INGEST
+          value: "false"
+        - name: NODE_DATA
+          value: "false"
+        - name: HTTP_ENABLE
+          value: "false"
+        - name: ES_JAVA_OPTS
+          value: -Xms256m -Xmx256m
+        - name: PROCESSORS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        resources:
+          limits:
+            cpu: 1
+        ports:
+        - containerPort: 9300
+          name: transport
+        livenessProbe:
+          tcpSocket:
+            port: transport
+        volumeMounts:
+        - name: storage
+          mountPath: /data
+      volumes:
+          - emptyDir:
+              medium: ""
+            name: "storage"

--- a/feature-demos/logging/efk/logging/efk-ha-stack/es-svc.yaml
+++ b/feature-demos/logging/efk/logging/efk-ha-stack/es-svc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch
+  namespace: logging
+  labels:
+    component: elasticsearch
+    role: client
+spec:
+  selector:
+    component: elasticsearch
+    role: client
+  ports:
+  - name: http
+    port: 9200
+#type: LoadBalancer

--- a/feature-demos/logging/efk/logging/efk-ha-stack/fluentd-config.yaml
+++ b/feature-demos/logging/efk/logging/efk-ha-stack/fluentd-config.yaml
@@ -1,0 +1,309 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: fluentd-config
+  namespace: logging
+  labels:
+    k8s-app: fluentd
+data:
+  fluentd.conf: |
+    # Use the config specified by the FLUENTD_CONFIG environment variable, or
+    # default to fluentd-standalone.conf
+    @include "#{ENV['FLUENTD_CONFIG'] || 'fluentd-standalone.conf'}"
+  # A config for running Fluentd as a daemon which collects, filters, parses,
+  # and sends log to storage. No extra fluentd processes required.
+  fluentd-standalone.conf: |
+    # Common config
+    @include general.conf
+    @include prometheus.conf
+    # Input sources
+    @include kubernetes-input.conf
+    @include apiserver-audit-input.conf
+    # Parsing/Filtering
+    @include kubernetes-filter.conf
+    @include extra.conf
+    # Send to storage
+    @include output.conf
+  # A config for running Fluentd as a daemon which collects logs and forwards
+  # the logs using a forward_output to a Fluentd configured as an aggregator,
+  # with a forward_input.
+  fluentd-forwarder.conf: |
+    @include general.conf
+    @include prometheus.conf
+    @include apiserver-audit-input.conf
+    @include systemd-input.conf
+    @include kubernetes-input.conf
+    # Send to the aggregator
+    @include forward-output.conf
+  # A config for running Fluentd as HA ready deployment for receiving forwarded
+  # logs, and then applying filtering, and parsing before sending them to
+  # storage.
+  fluentd-aggregator.conf: |
+    # Receive from the forwarder
+    @include forward-input.conf
+    @include general.conf
+    @include prometheus.conf
+    @include systemd-filter.conf
+    @include kubernetes-filter.conf
+    @include extra.conf
+    # Send to storage
+    @include output.conf
+  forward-input.conf: |
+    <source>
+      @type forward
+      port 24224
+      bind 0.0.0.0
+    </source>
+  forward-output.conf: |
+    <match **>
+      @type forward
+      require_ack_response true
+      ack_response_timeout 30
+      recover_wait 10s
+      heartbeat_interval 1s
+      phi_threshold 16
+      send_timeout 10s
+      hard_timeout 10s
+      expire_dns_cache 15
+      heartbeat_type tcp
+      buffer_chunk_limit 2M
+      buffer_queue_limit 32
+      flush_interval 5s
+      max_retry_wait 15
+      disable_retry_limit
+      num_threads 8
+      <server>
+        name fluentd-aggregator
+        host fluentd-aggregator.logging.svc.cluster.local
+        weight 60
+      </server>
+    </match>
+  general.conf: |
+    # Prevent fluentd from handling records containing its own logs. Otherwise
+    # it can lead to an infinite loop, when error in sending one message generates
+    # another message which also fails to be sent and so on.
+    <match fluent.**>
+      @type null
+    </match>
+    # Used for health checking
+    <source>
+      @type http
+      port 9880
+      bind 0.0.0.0
+    </source>
+    # Emits internal metrics to every minute, and also exposes them on port
+    # 24220. Useful for determining if an output plugin is retryring/erroring,
+    # or determining the buffer queue length.
+    <source>
+      @type monitor_agent
+      bind 0.0.0.0
+      port 24220
+      tag fluentd.monitor.metrics
+    </source>
+  prometheus.conf: |
+    # input plugin that is required to expose metrics by other prometheus
+    # plugins, such as the prometheus_monitor input below.
+    <source>
+      @type prometheus
+      bind 0.0.0.0
+      port 24231
+      metrics_path /metrics
+    </source>
+    # input plugin that collects metrics from MonitorAgent and exposes them
+    # as prometheus metrics
+    <source>
+      @type prometheus_monitor
+      # update the metrics every 5 seconds
+      interval 5
+    </source>
+    <source>
+      @type prometheus_output_monitor
+      interval 5
+    </source>
+    <source>
+      @type prometheus_tail_monitor
+      interval 5
+    </source>
+  systemd.conf: |
+    @include systemd-input.conf
+    @include systemd-filter.conf
+  systemd-input.conf: |
+    <source>
+      @type systemd
+      pos_file /var/log/fluentd-journald-systemd.pos
+      read_from_head true
+      strip_underscores true
+      tag systemd
+    </source>
+  systemd-filter.conf: |
+    <match systemd>
+      @type rewrite_tag_filter
+      rewriterule1 SYSTEMD_UNIT   ^(.+).service$  systemd.$1
+      rewriterule2 SYSTEMD_UNIT   !^(.+).service$ systemd.unmatched
+    </match>
+    <filter systemd.kubelet>
+      @type parser
+      format kubernetes
+      reserve_data true
+      key_name MESSAGE
+      suppress_parse_error_log true
+    </filter>
+    <filter systemd.docker>
+      @type parser
+      format /^time="(?<time>[^)]*)" level=(?<severity>[^ ]*) msg="(?<message>[^"]*)"( err="(?<error>[^"]*)")?( statusCode=($<status_code>\d+))?/
+      reserve_data true
+      key_name MESSAGE
+      suppress_parse_error_log true
+    </filter>
+    # Filter filter ssh logs since it's mostly bots trying to login
+    <filter systemd.**>
+      @type grep
+      exclude1 SYSTEMD_UNIT (sshd@.*\.service)
+    </filter>
+  kubernetes.conf: |
+    @include kubernetes-input.conf
+    @include kubernetes-filter.conf
+  kubernetes-input.conf: |
+    # Capture Kubernetes pod logs
+    # The kubelet creates symlinks that capture the pod name, namespace,
+    # container name & Docker container ID to the docker logs for pods in the
+    # /var/log/containers directory on the host.
+    <source>
+      @type tail
+      path /var/log/containers/*.log
+      pos_file /var/log/fluentd-containers.log.pos
+      time_format %Y-%m-%dT%H:%M:%S.%NZ
+      tag kubernetes.*
+      format json
+      read_from_head true
+    </source>
+  kubernetes-filter.conf: |
+    # Query the API for extra metadata.
+    <filter kubernetes.**>
+      @type kubernetes_metadata
+      # If the logs begin with '{' and end with '}' then it's JSON so merge
+      # the JSON log field into the log event
+      merge_json_log true
+      preserve_json_log true
+    </filter>
+    # rewrite_tag_filter does not support nested fields like
+    # kubernetes.container_name, so this exists to flatten the fields
+    # so we can use them in our rewrite_tag_filter
+    <filter kubernetes.**>
+      @type record_transformer
+      enable_ruby true
+      <record>
+        kubernetes_namespace_container_name ${record["kubernetes"]["namespace_name"]}.${record["kubernetes"]["container_name"]}
+      </record>
+    </filter>
+    # retag based on the container name of the log message
+    <match kubernetes.**>
+      @type rewrite_tag_filter
+      rewriterule1 kubernetes_namespace_container_name  ^(.+)$ kube.$1
+    </match>
+    # Remove the unnecessary field as the information is already available on
+    # other fields.
+    <filter kube.**>
+      @type record_transformer
+      remove_keys kubernetes_namespace_container_name
+    </filter>
+    <filter kube.kube-system.**>
+      @type parser
+      format kubernetes
+      reserve_data true
+      key_name log
+      suppress_parse_error_log true
+    </filter>
+  apiserver-audit-input.conf: |
+    # Example:
+    # 2017-02-09T00:15:57.992775796Z AUDIT: id="90c73c7c-97d6-4b65-9461-f94606ff825f" ip="104.132.1.72" method="GET" user="kubecfg" as="<self>" asgroups="<lookup>" namespace="default" uri="/api/v1/namespaces/default/pods"
+    # 2017-02-09T00:15:57.993528822Z AUDIT: id="90c73c7c-97d6-4b65-9461-f94606ff825f" response="200"
+    <source>
+      @type tail
+      format multiline
+      multiline_flush_interval 5s
+      format_firstline /^\S+\s+AUDIT:/
+      # Fields must be explicitly captured by name to be parsed into the record.
+      # Fields may not always be present, and order may change, so this just looks
+      # for a list of key="\"quoted\" value" pairs separated by spaces.
+      # Unknown fields are ignored.
+      # Note: We can't separate query/response lines as format1/format2 because
+      #       they don't always come one after the other for a given query.
+      format1 /^(?<time>\S+) AUDIT:(?: (?:id="(?<id>(?:[^"\\]|\\.)*)"|ip="(?<ip>(?:[^"\\]|\\.)*)"|method="(?<method>(?:[^"\\]|\\.)*)"|user="(?<user>(?:[^"\\]|\\.)*)"|groups="(?<groups>(?:[^"\\]|\\.)*)"|as="(?<as>(?:[^"\\]|\\.)*)"|asgroups="(?<asgroups>(?:[^"\\]|\\.)*)"|namespace="(?<namespace>(?:[^"\\]|\\.)*)"|uri="(?<uri>(?:[^"\\]|\\.)*)"|response="(?<response>(?:[^"\\]|\\.)*)"|\w+="(?:[^"\\]|\\.)*"))*/
+      time_format %FT%T.%L%Z
+      path /var/log/kubernetes/kube-apiserver-audit.log
+      pos_file /var/log/kube-apiserver-audit.log.pos
+      tag kube-apiserver-audit
+    </source>
+  output.conf: |
+    <match **>
+      # Plugin specific settings
+      @type cloudwatch_logs
+      log_group_name kubernetes-logs
+      log_stream_name fluentd-cloudwatch
+      auto_create_stream true
+      # Buffer settings
+      buffer_chunk_limit 2M
+      buffer_queue_limit 32
+      flush_interval 10s
+      max_retry_wait 30
+      disable_retry_limit
+      num_threads 8
+    </match>
+  elasticsearch-template-es5x.json: |
+    {
+      "template" : "logstash-*",
+      "version" : 50001,
+      "settings" : {
+        "index.refresh_interval" : "5s",
+        "number_of_shards": 1
+      },
+      "mappings" : {
+        "_default_" : {
+          "_all" : {"enabled" : true, "norms" : false},
+          "dynamic_templates" : [ {
+            "message_field" : {
+              "path_match" : "message",
+              "match_mapping_type" : "string",
+              "mapping" : {
+                "type" : "text",
+                "norms" : false
+              }
+            }
+          }, {
+            "string_fields" : {
+              "match" : "*",
+              "match_mapping_type" : "string",
+              "mapping" : {
+                "type" : "text", "norms" : false,
+                "fields" : {
+                  "keyword" : { "type": "keyword" }
+                }
+              }
+            }
+          } ],
+          "properties" : {
+            "@timestamp": { "type": "date", "include_in_all": false },
+            "@version": { "type": "keyword", "include_in_all": false },
+            "geoip"  : {
+              "dynamic": true,
+              "properties" : {
+                "ip": { "type": "ip" },
+                "location" : { "type" : "geo_point" },
+                "latitude" : { "type" : "half_float" },
+                "longitude" : { "type" : "half_float" }
+              }
+            }
+          }
+        }
+      }
+    }
+  extra.conf: |
+    # Example filter that adds an extra field "cluster_name" to all log
+    # messages:
+    # <filter **>
+    #   @type record_transformer
+    #   <record>
+    #     cluster_name "your_cluster_name"
+    #   </record>
+    # </filter>

--- a/feature-demos/logging/efk/logging/efk-ha-stack/fluentd.yaml
+++ b/feature-demos/logging/efk/logging/efk-ha-stack/fluentd.yaml
@@ -1,0 +1,115 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluentd
+  namespace: logging
+  labels:
+    k8s-app: fluentd
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: fluentd
+  namespace: logging
+  labels:
+    k8s-app: fluentd
+rules:
+- apiGroups: [""]
+  resources: ["namespaces", "nodes/proxy", "pods", "pods/log"]
+  verbs: ["get","list","watch"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: fluentd
+  namespace: logging
+  labels:
+    k8s-app: fluentd
+subjects:
+- kind: ServiceAccount
+  name: fluentd
+  namespace: logging
+roleRef:
+  kind: ClusterRole
+  name: fluentd
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: fluentd
+  namespace: logging
+  labels:
+    k8s-app: fluentd-logging
+    version: v1
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: fluentd-logging
+        version: v1
+        kubernetes.io/cluster-service: "true"
+    spec:
+      serviceAccountName: fluentd
+      tolerations:
+      - key: node-role.kubernetes.io/ismaster
+        effect: NoSchedule
+      - effect: NoSchedule
+        operator: Exists
+      - effect: NoExecute
+        key: node.alpha.kubernetes.io/notReady
+        operator: Exists
+      - effect: NoExecute
+        key: node.alpha.kubernetes.io/unreachable
+        operator: Exists
+      containers:
+      - name: fluentd
+        image: fluent/fluentd-kubernetes-daemonset:elasticsearch
+        env:
+          - name:  FLUENT_ELASTICSEARCH_HOST
+            value: "elasticsearch"
+          - name:  FLUENT_ELASTICSEARCH_PORT
+            value: "9200"
+          - name: FLUENT_ELASTICSEARCH_SCHEME
+            value: "http"
+          # X-Pack Authentication
+          # =====================
+          - name: FLUENT_ELASTICSEARCH_USER
+            value: "elastic"
+          - name: FLUENT_ELASTICSEARCH_PASSWORD
+            value: "changeme"
+        resources:
+          limits:
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: libsystemddir
+          mountPath: /host/lib
+          readOnly: true
+        - name: config-volume
+          mountPath: /etc/fluent/config.d
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: libsystemddir
+        hostPath:
+          path: /usr/lib64
+      - name: config-volume
+        configMap:
+          name: fluentd-config
+                                                                      

--- a/feature-demos/logging/efk/logging/efk-ha-stack/kibana.yaml
+++ b/feature-demos/logging/efk/logging/efk-ha-stack/kibana.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: kibana-logging
+  labels:
+    app: kibana-logging
+  namespace: logging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kibana-logging
+  template:
+    metadata:
+      labels:
+        app: kibana-logging
+    spec:
+      containers:
+      - name: kibana-logging
+        image: docker.elastic.co/kibana/kibana-oss:6.2.2 
+        resources:
+          limits:
+            cpu: 1000m
+          requests:
+            cpu: 100m
+        env:
+        - name: ELASTICSEARCH_URL
+          value: http://elasticsearch:9200
+       # - name: SERVER_BASEPATH
+       #   value: "/api/v1/proxy/namespaces/kube-system/services/kibana-logging"
+       # - name: SERVER_NAME
+       #   value: "kibana.example.org"
+        ports:
+        - name: ui
+          containerPort: 5601
+          protocol: TCP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kibana-logging
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: Kibana
+  name: kibana-logging
+  namespace: logging
+spec:
+  ports:
+  - nodePort: 30560
+    port: 80
+    protocol: TCP
+    targetPort: ui
+  selector:
+    app: kibana-logging
+  type: NodePort


### PR DESCRIPTION
This commit adds the EFK (HA) setup configs and README.

Changes to be committed:
	new file:   logging/efk-ha-stack/README.md
	new file:   logging/efk-ha-stack/es-client.yaml
	new file:   logging/efk-ha-stack/es-data.yaml
	new file:   logging/efk-ha-stack/es-discovery-svc.yaml
	new file:   logging/efk-ha-stack/es-master.yaml
	new file:   logging/efk-ha-stack/es-svc.yaml
	new file:   logging/efk-ha-stack/fluentd-config.yaml
	new file:   logging/efk-ha-stack/fluentd.yaml
	new file:   logging/efk-ha-stack/kibana.yaml

Signed-off-by: utkarshmani1997 <utkarshmani1997@gmail.com>