### PR TITLE
Pin volume replica to K8s node

### DIFF
--- a/feature-demos/volumepolicies/replica-pinning/README.md
+++ b/feature-demos/volumepolicies/replica-pinning/README.md
@@ -1,0 +1,207 @@
+## Agenda
+
+- Pin volume replica to K8s node
+  - Issue - https://github.com/openebs/openebs/issues/1310
+  - PR - 
+
+NOTE: This will work once above PR is merged!
+
+### Assumptions
+- openebs/maya's master branch is being used
+- A kubernetes setup
+  - We will use minikube
+  - NOTE: A multi-node cluster will be better to verify this behaviour
+- Basic knowledge of:
+  - Kubernetes Pod
+  - Kubernetes PersistentVolumeClaim
+  - Kubernetes StorageClass
+  - Kubernetes CRD
+  - Kubernetes ConfigMap
+  - Kubernetes Deployment
+  - Kubernetes Service
+  - Kubernetes Patch
+  - Kubernetes Node Affinity
+
+### What is nodeAffinity?
+- Node affinity is conceptually similar to nodeSelector
+- It allows you to constrain which nodes your pod is eligible to be scheduled on
+- It is based on labels on the node
+- There are currently two types of node affinity:
+  - requiredDuringSchedulingIgnoredDuringExecution &
+  - preferredDuringSchedulingIgnoredDuringExecution
+- These node affinity types can be thought of “hard” vs. “soft” affinity respectively
+
+### Why does OpenEBS need nodeAffinity?
+- OpenEBS volume replicas need to be sticky to the nodes where they got scheduled
+- It is not convinient to move data across nodes if replicas keep moving around
+
+### Why not nodeSelector?
+- node affinity is more expressive than nodeSelector
+- node affinity can specify requirements better than nodeSelector
+- nodeSelector will be deprecated in favour of node affinity
+
+### Sample Specifications
+
+- sample volumepolicy snippet:
+```yaml
+  run:
+    searchNamespace: default
+    tasks:
+    - template: volume-service-0.6.0
+      identity: vsvc
+    - template: volume-path-0.6.0
+      identity: vpath
+    - template: volume-pvc-0.6.0
+      identity: vpvc
+    - template: volume-controller-0.6.0
+      identity: vctrl
+    - template: volume-replica-0.6.0
+      identity: vrep
+    - template: volume-replica-list-0.6.0
+      identity: vreplist
+    - template: volume-replica-patch-0.6.0
+      identity: vreppatch
+```
+
+- sample volume replica list template:
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: volume-replica-list-0.6.0
+  annotations:
+    openebs.io/policy: VolumePolicy
+    policy.openebs.io/version: 0.6.0
+  namespace: default
+data:
+  meta: |
+    runNamespace: {{ .Volume.runNamespace }}
+    apiVersion: v1
+    kind: Pod
+    action: list
+    options: |-
+      labelSelector: openebs.io/replica=jiva-replica,openebs.io/pv={{ .Volume.owner }}
+    queries:
+    - alias: objectName
+    - alias: nodeNames
+      path: |-
+        {.items[*].spec.nodeName}
+      verify:
+        split: " "
+        count: {{ .Policy.ReplicaCount.value }}
+```
+
+- sample volume replica patch template:
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: volume-replica-patch-0.6.0
+  annotations:
+    openebs.io/policy: VolumePolicy
+    policy.openebs.io/version: 0.6.0
+  namespace: default
+data:
+  meta: |
+    runNamespace: {{ .Volume.runNamespace }}
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    objectName: {{ .Volume.owner }}-rep
+    action: patch
+    patches: |-
+      spec:
+        template:
+          spec:
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                  - matchExpressions:
+                    - key: kubernetes.io/hostname
+                      operator: In
+                      values:
+                      {{- $nodeNamesMap := .TaskResult.vreplist.nodeNames | split " " }}
+                      {{- range $k, $v := $nodeNamesMap }}
+                      - {{ $v }}
+                      {{- end }}
+                  - $patch: merge
+```
+
+#### SETUP
+```bash
+# Deploy kubectl, minikube, helm, & openebs charts
+sh ./setup.sh
+
+# Customize openebs operator
+cd .tmp/openebs && \
+  helm install --debug --dry-run ./ \
+  --name ci \
+  --set apiserver.imageTag="1310",apiserver.replicas="1",provisioner.replicas="1" \
+  | sed -n '/---/,$p' > openebs-operator-autogen.yaml && \
+  cd ../..
+
+# NOTE: Remove openebs provisioner deployment from above autogen file
+This is done to test the replica pinning logic via maya api server only
+
+# View the operator file & verify its correctness
+cat .tmp/openebs/openebs-operator-autogen.yaml
+
+# Deploy openebs operator components
+kubectl create -f crds.yaml
+kubectl create -f .tmp/openebs/openebs-operator-autogen.yaml
+
+# Deploy openebs volume policies
+# NOTE: Read this yaml to understand the volume policy details
+# - Shows how to use volume policy as a task workflow
+# - Shows how a volume policy uses templates as its tasks
+kubectl create -f vol-policies.yaml
+```
+
+#### RUN
+```bash
+# Use maya apiserver service cluster IP
+kubectl get svc --all-namespaces
+
+# ADD openebs volume using /v1alpha1/ URL path
+
+curl -k -H "Content-Type: application/yaml" -XPOST \
+  -d"$(cat oe-vol-rep-pinning-060.yaml)" \
+  http://"$(kubectl get svc -n openebs ci-openebs-maya-apiservice --template={{.spec.clusterIP}})":5656/v1alpha1/volumes/
+
+# VERIFY if controller & replica pods & volume service are running or available
+
+
+# DELETE the openebs volume using /latest/ URL path
+curl -H "namespace: default" http://"$(kubectl get svc -n openebs ci-openebs-maya-apiservice --template={{.spec.clusterIP}})":5656/latest/volumes/delete/jivavolpol
+```
+
+#### TEARDOWN
+```bash
+# 1/ delete openebs volume policies
+kubectl delete -f vol-policies.yaml
+
+# 2/ delete openebs operator components
+kubectl delete -f .tmp/openebs/openebs-operator-autogen.yaml
+kubectl delete -f crds.yaml
+```
+
+### Troubleshooting
+
+#### Issue 1:
+Inter-pod affinity and anti-affinity require substantial amount of processing which can slow down scheduling in large clusters significantly. We do not recommend using them in clusters larger than several hundred nodes.
+
+### References
+- https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+- https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/util/jsonpath/jsonpath_test.go
+- https://github.com/Masterminds/sprig/blob/master/doc.go
+- https://github.com/kubernetes/community/blob/master/contributors/devel/strategic-merge-patch.md
+- https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
+- https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+
+### Extras
+- Understand patch using kubectl in verbose mode
+```bash
+kubectl create -f mock_deployment.yaml
+kubectl patch deployment nginx -p "$(cat mock_patch.yaml)" --v=9
+kubectl patch deployment nginx -p "$(cat mock_patch_2.yaml)" --v=9
+```

--- a/feature-demos/volumepolicies/replica-pinning/crds.yaml
+++ b/feature-demos/volumepolicies/replica-pinning/crds.yaml
@@ -1,0 +1,22 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: volumepolicies.openebs.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1alpha1
+  # either Namespaced or Cluster
+  scope: Cluster
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: volumepolicies
+    # singular name to be used as an alias on the CLI and for display
+    singular: volumepolicy
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: VolumePolicy
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - vp

--- a/feature-demos/volumepolicies/replica-pinning/mock_deployment.yaml
+++ b/feature-demos/volumepolicies/replica-pinning/mock_deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx-con
+        image: nginx
+        imagePullPolicy: IfNotPresent
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  app: nginx

--- a/feature-demos/volumepolicies/replica-pinning/mock_deployment_node_affinity.yaml
+++ b/feature-demos/volumepolicies/replica-pinning/mock_deployment_node_affinity.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx-con
+        image: nginx
+        imagePullPolicy: IfNotPresent
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/os
+                operator: In
+                values:
+                - linux
+              - key: kubernetes.io/hostname
+                operator: In
+                values:
+                - amit-thinkpad-l4702

--- a/feature-demos/volumepolicies/replica-pinning/mock_patch.yaml
+++ b/feature-demos/volumepolicies/replica-pinning/mock_patch.yaml
@@ -1,0 +1,13 @@
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: In
+                values:
+                - amit-thinkpad-l470
+        podAntiAffinity: null

--- a/feature-demos/volumepolicies/replica-pinning/mock_patch_2.yaml
+++ b/feature-demos/volumepolicies/replica-pinning/mock_patch_2.yaml
@@ -1,0 +1,12 @@
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/os
+                operator: In
+                values:
+                - linux

--- a/feature-demos/volumepolicies/replica-pinning/mock_patch_task_tpl.yaml
+++ b/feature-demos/volumepolicies/replica-pinning/mock_patch_task_tpl.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: volume-replica-patch-0.6.0
+  annotations:
+    openebs.io/policy: VolumePolicy
+    policy.openebs.io/version: 0.6.0
+  namespace: default
+data:
+  meta: |
+    runNamespace: {{ .Volume.runNamespace }}
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    objectName: {{ .Volume.owner }}-rep
+    action: patch
+    queries:
+    - alias: objectName
+    patch:
+      type: strategic
+      pspec: |-
+        spec:
+          template:
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: kubernetes.io/hostname
+                        operator: In
+                        values:
+                        {{- if ne .TaskResult.vreplist.nodeNames "" }}
+                        {{- $nodeNamesMap := .TaskResult.vreplist.nodeNames | split " " }}
+                        {{- range $k, $v := $nodeNamesMap }}
+                        - {{ $v }}
+                        {{- end }}
+                        {{- end }}

--- a/feature-demos/volumepolicies/replica-pinning/oe-vol-rep-pinning-060.yaml
+++ b/feature-demos/volumepolicies/replica-pinning/oe-vol-rep-pinning-060.yaml
@@ -1,0 +1,13 @@
+kind: OpenEBSVolume
+apiVersion: v1
+metadata:
+  name: jivavolpol
+  labels:
+    # old way - capacity
+    volumeprovisioner.mapi.openebs.io/storage-size: 2G
+    k8s.io/storage-class: openebs-repaffinity-0.6.0
+    # old way - namespace
+    k8s.io/namespace: default
+    k8s.io/pvc: openebs-repaffinity-0.6.0
+capacity: 2G
+namespace: default

--- a/feature-demos/volumepolicies/replica-pinning/openebs-operator-autogen.yaml
+++ b/feature-demos/volumepolicies/replica-pinning/openebs-operator-autogen.yaml
@@ -1,0 +1,580 @@
+---
+# Source: openebs/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openebs
+---
+# Source: openebs/templates/cm-openebs-prometheus-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ci-openebs-prometheus-config
+  namespace: openebs
+  labels:
+    app: openebs
+    chart: openebs-0.5.3
+    release: ci
+    heritage: Tiller
+    component: ci-openebs
+    role: prometheus-config
+data:
+  prometheus.yml: |-
+    global:
+      external_labels:
+        slave: slave1
+      scrape_interval: 5s
+      evaluation_interval: 5s
+    scrape_configs:
+    #- job_name: 'prometheus'
+      #static_configs:
+      # Added this to allow for federation collection
+      # Replace localhost with the nodeIP
+      #  - targets: ['localhost:32514']
+    - job_name: 'openebs-prometheus-server'
+      scheme: http
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_name]
+        regex: openebs-prometheus-server
+        action: keep
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: kubernetes_pod_name
+    - job_name: 'openebs-volumes'
+      scheme: http
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_monitoring]
+        regex: volume_exporter_prometheus
+        action: keep
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: kubernetes_pod_name
+      - source_labels: [__meta_kubernetes_pod_label_vsm]
+        action: replace
+        target_label: openebs_pv
+      - source_labels: [__meta_kubernetes_pod_container_port_number]
+        action: drop
+        regex: '(.*)9501'
+      - source_labels: [__meta_kubernetes_pod_container_port_number]
+        action: drop
+        regex: '(.*)3260'
+---
+# Source: openebs/templates/cm-openebs-prometheus-tunables.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ci-openebs-prometheus-tunables
+  namespace: openebs
+  labels:
+    app: openebs
+    chart: openebs-0.5.3
+    release: ci
+    heritage: Tiller
+    component: ci-openebs
+    role: prometheus-tunables
+data:
+  storage-retention: 24h
+---
+# Source: openebs/templates/sc-openebs-cassandra.yaml
+# Define a storage classes supported by OpenEBS
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-cassandra
+  labels:
+    chart: "openebs-0.5.3"
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "3"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: 5G
+---
+# Source: openebs/templates/sc-openebs-es-data-sc.yaml
+# Define a storage classes supported by OpenEBS
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-es-data-sc
+  labels:
+    chart: "openebs-0.5.3"
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "3"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: 5G
+---
+# Source: openebs/templates/sc-openebs-jupyter.yaml
+# Define a storage classes supported by OpenEBS
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-jupyter
+  labels:
+    chart: "openebs-0.5.3"
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "3"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: 5G
+---
+# Source: openebs/templates/sc-openebs-kafka.yaml
+# Define a storage classes supported by OpenEBS
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-kafka
+  labels:
+    chart: "openebs-0.5.3"
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "3"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: 5G
+---
+# Source: openebs/templates/sc-openebs-mongodb.yaml
+# Define a storage classes supported by OpenEBS
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-mongodb
+  labels:
+    chart: "openebs-0.5.3"
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "3"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: 5G
+---
+# Source: openebs/templates/sc-openebs-percona.yaml
+# Define a storage classes supported by OpenEBS
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-percona
+  labels:
+    chart: "openebs-0.5.3"
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "3"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: 5G
+---
+# Source: openebs/templates/sc-openebs-redis.yaml
+# Define a storage classes supported by OpenEBS
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-redis
+  labels:
+    chart: "openebs-0.5.3"
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "3"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: 5G
+---
+# Source: openebs/templates/sc-openebs-standalone.yaml
+# Define a storage classes supported by OpenEBS
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-standalone
+  labels:
+    chart: "openebs-0.5.3"
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "1"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: 5G
+---
+# Source: openebs/templates/sc-openebs-standard.yaml
+# Define a storage classes supported by OpenEBS
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-standard
+  labels:
+    chart: "openebs-0.5.3"
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "3"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: 5G
+---
+# Source: openebs/templates/sc-openebs-zk.yaml
+# Define a storage classes supported by OpenEBS
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-zk
+  labels:
+    chart: "openebs-0.5.3"
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "3"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: 5G
+---
+# Source: openebs/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openebs-maya-operator
+  namespace: openebs
+  labels:
+    chart: "openebs-0.5.3"
+---
+# Source: openebs/templates/crd-sp.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: storagepools.openebs.io
+  labels:
+    chart: "openebs-0.5.3"
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1alpha1
+  # either Namespaced or Cluster
+  scope: Cluster
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: storagepools
+    # singular name to be used as an alias on the CLI and for display
+    singular: storagepool
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: StoragePool
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - sp
+---
+# Source: openebs/templates/crd-spc.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: storagepoolclaims.openebs.io
+  labels:
+    chart: "openebs-0.5.3"
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1alpha1
+  # either Namespaced or Cluster
+  scope: Cluster
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: storagepoolclaims
+    # singular name to be used as an alias on the CLI and for display
+    singular: storagepoolclaim
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: StoragePoolClaim
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - spc
+---
+# Source: openebs/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: openebs-maya-operator
+  labels:
+    chart: "openebs-0.5.3"
+rules:
+- apiGroups: ["*"]
+  resources: ["nodes","nodes/proxy"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["*"]
+  resources: ["namespaces", "services", "pods", "deployments", "events", "endpoints", "configmaps"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["persistentvolumes","persistentvolumeclaims"]
+  verbs: ["*"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["storagepools", "volumepolicies"]
+  verbs: ["get", "list"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+# Source: openebs/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: openebs-maya-operator
+  labels:
+    chart: "openebs-0.5.3"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openebs-maya-operator
+subjects:
+- kind: ServiceAccount
+  name: openebs-maya-operator
+  namespace: openebs
+---
+# Source: openebs/templates/service-maya-apiserver.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ci-openebs-maya-apiservice
+  namespace: openebs
+  labels:
+    app: openebs
+    chart: openebs-0.5.3
+    release: ci
+    heritage: Tiller
+    role: apiserver
+spec:
+  ports:
+  - name: api
+    port: 5656
+    targetPort: 5656
+    protocol: TCP
+  selector:
+    app: openebs
+    release: ci
+    component: ci-openebs
+    role: apiserver
+  sessionAffinity: None
+---
+# Source: openebs/templates/service-openebs-grafana.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ci-openebs-grafana
+  namespace: openebs
+  labels:
+    app: openebs
+    chart: openebs-0.5.3
+    release: ci
+    heritage: Tiller
+    role: grafana
+spec:
+  type: NodePort
+  ports:
+  - port: 3000
+    targetPort: 3000
+    nodePort: 32515
+  selector:
+    app: openebs
+    release: ci
+    component: ci-openebs
+    role: grafana
+---
+# Source: openebs/templates/service-openebs-prometheus.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ci-openebs-prometheus-service
+  namespace: openebs
+  labels:
+    app: openebs
+    chart: openebs-0.5.3
+    release: ci
+    heritage: Tiller
+    role: prometheus
+spec:
+  type: NodePort
+  ports:
+  - port: 80 # this Service's port (cluster-internal IP clusterIP)
+    targetPort: 9090 # pods expose this port
+    nodePort: 32514
+    # Note that this Service will be visible as both NodeIP:nodePort and clusterIp:Port
+  selector:
+    app: openebs
+    release: ci
+    component: ci-openebs
+    role: prometheus
+---
+# Source: openebs/templates/deployment-maya-apiserver.yaml
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: ci-openebs-maya-apiserver
+  namespace: openebs
+  labels:
+    app: openebs
+    chart: openebs-0.5.3
+    release: ci
+    heritage: Tiller
+    component: ci-openebs
+    role: apiserver
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: openebs
+        release: ci
+        component: ci-openebs
+        role: apiserver
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+      - name: openebs-maya-apiserver
+        image: "openebs/m-apiserver:1310"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 5656
+        env:
+        # OPENEBS_IO_KUBE_CONFIG enables maya api service to connect to K8s
+        # based on this config. This is ignored if empty.
+        # This is supported for maya api server version 0.5.2 onwards
+        #- name: OPENEBS_IO_KUBE_CONFIG
+        #  value: "/home/ubuntu/.kube/config"
+        # OPENEBS_IO_K8S_MASTER enables maya api service to connect to K8s
+        # based on this address. This is ignored if empty.
+        # This is supported for maya api server version 0.5.2 onwards
+        #- name: OPENEBS_IO_K8S_MASTER
+        #  value: "http://172.28.128.3:8080"
+        - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
+          value: "openebs/jiva:0.5.3"
+        - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
+          value: "openebs/jiva:0.5.3"
+        - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
+          value: "openebs/m-exporter:0.5.3"
+        - name: OPENEBS_IO_JIVA_REPLICA_COUNT
+          value: "3"
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  name: ci-openebs-maya-apiserver
+---
+# Source: openebs/templates/deployment-openebs-grafana.yaml
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: ci-openebs-grafana
+  namespace: openebs
+  labels:
+    app: openebs
+    chart: openebs-0.5.3
+    release: ci
+    heritage: Tiller
+    component: ci-openebs
+    role: grafana
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  template:
+    metadata:
+      labels:
+        app: openebs
+        release: ci
+        component: ci-openebs
+        role: grafana
+    spec:
+      containers:
+      - name: openebs-grafana
+        image: "grafana/grafana:4.6.3"
+        ports:
+        - containerPort: 3000
+        env:
+          - name: GF_AUTH_BASIC_ENABLED
+            value: "true"
+          - name: GF_AUTH_ANONYMOUS_ENABLED
+            value: "false"
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
+---
+# Source: openebs/templates/deployment-openebs-prometheus.yaml
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: ci-openebs-prometheus
+  namespace: openebs
+  labels:
+    app: openebs
+    chart: openebs-0.5.3
+    release: ci
+    heritage: Tiller
+    component: ci-openebs
+    role: prometheus
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: openebs
+        release: ci
+        component: ci-openebs
+        role: prometheus
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+        - name: openebs-prometheus
+          image: "prom/prometheus:v2.1.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--config.file=/etc/prometheus/conf/prometheus.yml"
+            # Metrics are stored in an emptyDir volume which
+            # exists as long as the Pod is running on that Node.
+            # The data in an emptyDir volume is safe across container crashes.
+            - "--storage.tsdb.path=/prometheus"
+            # How long to retain samples in the local storage.
+            - "--storage.tsdb.retention=$(STORAGE_RETENTION)"
+          ports:
+            - containerPort: 9090
+          env:
+            # environment vars are stored in prometheus-env configmap.
+            - name: STORAGE_RETENTION
+              valueFrom:
+                configMapKeyRef:
+                  name: ci-openebs-prometheus-tunables
+                  key: storage-retention
+          resources:
+            requests:
+              # A memory request of 250M means it will try to ensure minimum
+              # 250MB RAM .
+              memory: "128M"
+              # A cpu request of 128m means it will try to ensure minimum
+              # .125 CPU; where 1 CPU means :
+              # 1 *Hyperthread* on a bare-metal Intel processor with Hyperthreading
+              cpu: "128m"
+            limits:
+              memory: "700M"
+              cpu: "500m"
+          
+          volumeMounts:
+            # prometheus config file stored in the given mountpath
+            - name: prometheus-server-volume
+              mountPath: /etc/prometheus/conf
+            # metrics collected by prometheus will be stored at the given mountpath.
+            - name: prometheus-storage-volume
+              mountPath: /prometheus
+      volumes:
+        # Prometheus Config file will be stored in this volume 
+        - name: prometheus-server-volume
+          configMap:
+            name: ci-openebs-prometheus-config
+        # All the time series stored in this volume in form of .db file.
+        - name: prometheus-storage-volume
+          # containers in the Pod can all read and write the same files here.
+          emptyDir: {}

--- a/feature-demos/volumepolicies/replica-pinning/setup.sh
+++ b/feature-demos/volumepolicies/replica-pinning/setup.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env sh
+
+set -o errexit
+set -o nounset
+
+CURDIR=`pwd`
+
+#Install latest minikube
+ls /usr/local/bin/minikube || \
+(curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 \
+&& chmod +x minikube \
+&& sudo mv minikube /usr/local/bin/)
+
+#Install latest kubectl
+ls /usr/local/bin/kubectl || \
+(curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
+&& chmod +x kubectl \
+&& sudo mv kubectl /usr/local/bin/)
+
+#Setup minikube
+mkdir -p $HOME/.minikube
+mkdir -p $HOME/.kube
+touch $HOME/.kube/config
+
+# Push these ENV k:v to $HOME/.profile to start/restart minikube.
+grep "MINIKUBE_WANTUPDATENOTIFICATION=false" $HOME/.profile || \
+  echo "MINIKUBE_WANTUPDATENOTIFICATION=false" >> $HOME/.profile
+
+grep "MINIKUBE_WANTREPORTERRORPROMPT=false" $HOME/.profile || \
+  echo "MINIKUBE_WANTREPORTERRORPROMPT=false" >> $HOME/.profile
+
+grep "MINIKUBE_HOME=$HOME" $HOME/.profile || \
+  echo "MINIKUBE_HOME=$HOME" >> $HOME/.profile
+
+grep "CHANGE_MINIKUBE_NONE_USER=true" $HOME/.profile || \
+  echo "CHANGE_MINIKUBE_NONE_USER=true" >> $HOME/.profile
+
+grep "KUBECONFIG=$HOME/.kube/config" $HOME/.profile || \
+  echo "KUBECONFIG=$HOME/.kube/config" >> $HOME/.profile
+
+# Export above as well for `minikube start` to work 
+# in the same session of `vagrant up`
+export MINIKUBE_WANTUPDATENOTIFICATION=false
+export MINIKUBE_WANTREPORTERRORPROMPT=false
+export MINIKUBE_HOME=$HOME
+export CHANGE_MINIKUBE_NONE_USER=true
+export KUBECONFIG=$HOME/.kube/config
+
+# Permissions
+sudo chown -R $USER $HOME/.kube
+sudo chgrp -R $USER $HOME/.kube
+
+sudo chown -R $USER $HOME/.minikube
+sudo chgrp -R $USER $HOME/.minikube
+
+# Start minikube on this host itself with RBAC enabled
+sudo -E minikube start --vm-driver=none --extra-config=apiserver.Authorization.Mode=RBAC
+
+# Wait for Kubernetes to be up and ready.
+JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
+
+echo ""
+echo "================================================"
+echo "Congrats!! minikube apiserver is running"
+echo "================================================"
+echo ""
+
+# install socat
+sudo apt-get install socat
+
+# temp folder
+mkdir -p .tmp
+
+# Download and initialize helm
+ls .tmp/get_helm.sh ||
+(curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > .tmp/get_helm.sh \
+&& chmod 700 .tmp/get_helm.sh)
+
+bash .tmp/get_helm.sh
+helm init
+
+echo ""
+echo "================================================"
+echo "Congrats!! helm is installed"
+echo "================================================"
+echo ""
+
+# Patch the tiller with rbac rules
+kubectl -n kube-system create sa tiller \
+ || echo "Will skip creation of serviceaccounts tiller"
+
+kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller \
+ || echo "Will skip creation of clusterrolebindings tiller "
+
+kubectl -n kube-system patch deploy/tiller-deploy -p '{"spec": {"template": {"spec": {"serviceAccountName": "tiller"}}}}' \
+ || echo "Will skip patching of deploy/tiller-deploy"
+
+# Replace this with logic to wait till the pods are running
+sleep 30
+kubectl get pods --all-namespaces 
+kubectl get sa
+
+# Add openebs helm charts
+helm repo add openebs-charts https://openebs.github.io/charts/
+helm repo update
+helm repo list
+
+cd .tmp && helm fetch openebs-charts/openebs --untar
+
+cd ${CURDIR}

--- a/feature-demos/volumepolicies/replica-pinning/vol-policies.yaml
+++ b/feature-demos/volumepolicies/replica-pinning/vol-policies.yaml
@@ -1,0 +1,527 @@
+apiVersion: openebs.io/v1alpha1
+kind: StoragePool
+metadata:
+  name: ssd
+  type: hostdir
+spec:
+  path: "/var/myebs"
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: openebs-repaffinity-0.6.0
+  annotations:
+    controller.openebs.io/affinity: pinit
+    controller.openebs.io/affinity-topology: kubernetes.io/hostname
+    controller.openebs.io/affinity-type: soft
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: openebs-repaffinity-0.6.0
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-repaffinity-0.6.0
+  annotations:
+    provisioner.openebs.io/version: 0.6.0
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  openebs.io/volume-policy: openebs-policy-repaffinity-0.6.0
+---
+apiVersion: openebs.io/v1alpha1
+kind: VolumePolicy
+metadata:
+  name: openebs-policy-repaffinity-0.6.0
+spec:
+  policies:
+  - name: VolumeMonitor
+    enabled: "true"
+  - name: ControllerImage
+    value: openebs/jiva:0.5.0
+  - name: ReplicaImage
+    value: openebs/jiva:0.5.0
+  - name: ReplicaCount
+    value: "1"
+  - name: StoragePool
+    value: ssd
+  - name: TaintTolerations
+    value: |-
+      t1:
+        key: node.openebs.io/disktype
+        operator: Equal
+        value: ssd
+        effect: NoSchedule
+      t2:
+        key: node.openebs.io/disktype
+        operator: Equal
+        value: ssd
+        effect: NoExecute
+  - name: EvictionTolerations
+    value: |-
+      t1:
+        effect: NoExecute
+        key: node.alpha.kubernetes.io/notReady
+        operator: Exists
+      t2:
+        effect: NoExecute
+        key: node.alpha.kubernetes.io/unreachable
+        operator: Exists
+  - name: NodeAffinityRequiredSchedIgnoredExec
+    value: |-
+      t1:
+        key: beta.kubernetes.io/os
+        operator: In
+        values:
+        - linux
+  - name: NodeAffinityPreferredSchedIgnoredExec
+    value: |-
+      t1:
+        key: some-node-label-key
+        operator: In
+        values:
+        - some-node-label-value
+  run:
+    searchNamespace: default
+    tasks:
+    - template: volume-service-0.6.0
+      identity: vsvc
+    - template: volume-path-0.6.0
+      identity: vpath
+    - template: volume-pvc-0.6.0
+      identity: vpvc
+    - template: volume-controller-0.6.0
+      identity: vctrl
+    - template: volume-replica-0.6.0
+      identity: vrep
+    - template: volume-replica-list-0.6.0
+      identity: vreplist
+    - template: volume-replica-patch-0.6.0
+      identity: vreppatch
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: volume-service-0.6.0
+  annotations:
+    openebs.io/policy: VolumePolicy
+    policy.openebs.io/version: 0.6.0
+  namespace: default
+data:
+  meta: |
+    runNamespace: {{ .Volume.runNamespace }}
+    apiVersion: v1
+    kind: Service
+    action: put
+  task: |
+    apiVersion: v1
+    Kind: Service
+    metadata:
+      labels:
+        openebs/controller-service: jiva-controller-service
+        openebs.io/controller-service: jiva-controller-svc
+        openebs.io/storage-engine-type: jiva
+        openebs/volume-provisioner: jiva
+        vsm: {{ .Volume.owner }}
+        openebs.io/pv: {{ .Volume.owner }}
+      name: {{ .Volume.owner }}-ctrl-svc
+    spec:
+      ports:
+      - name: iscsi
+        port: 3260
+        protocol: TCP
+        targetPort: 3260
+      - name: api
+        port: 9501
+        protocol: TCP
+        targetPort: 9501
+      selector:
+        openebs/controller: jiva-controller
+        vsm: {{ .Volume.owner }}
+        openebs.io/controller: jiva-controller
+        openebs.io/pv: {{ .Volume.owner }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: volume-path-0.6.0
+  annotations:
+    openebs.io/policy: VolumePolicy
+    policy.openebs.io/version: 0.6.0
+  namespace: default
+data:
+  meta: |
+    runNamespace: {{ .Volume.runNamespace }}
+    apiVersion: openebs.io/v1alpha1
+    kind: StoragePool
+    objectName: {{ .Policy.StoragePool.value }}
+    action: get
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: volume-pvc-0.6.0
+  annotations:
+    openebs.io/policy: VolumePolicy
+    policy.openebs.io/version: 0.6.0
+  namespace: default
+data:
+  meta: |
+    runNamespace: {{ .Volume.runNamespace }}
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    objectName: {{ .Volume.pvc }}
+    action: get
+    queries:
+    - alias: objectName
+    - alias: affinity
+      path: |-
+        {.metadata.annotations.controller\.openebs\.io/affinity}
+    - alias: affinityTopology
+      path: |-
+        {.metadata.annotations.controller\.openebs\.io/affinity-topology}
+    - alias: affinityType
+      path: |-
+        {.metadata.annotations.controller\.openebs\.io/affinity-type}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: volume-replica-list-0.6.0
+  annotations:
+    openebs.io/policy: VolumePolicy
+    policy.openebs.io/version: 0.6.0
+  namespace: default
+data:
+  meta: |
+    runNamespace: {{ .Volume.runNamespace }}
+    apiVersion: v1
+    kind: Pod
+    action: list
+    options: |-
+      labelSelector: openebs.io/replica=jiva-replica,openebs.io/pv={{ .Volume.owner }}
+    retry: "10,30s"
+    queries:
+    - alias: objectName
+      path: |-
+        {.kind}
+    - alias: nodeNames
+      path: |-
+        {.items[*].spec.nodeName}
+      verify:
+        split: " "
+        count: {{ .Policy.ReplicaCount.value }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: volume-replica-patch-0.6.0
+  annotations:
+    openebs.io/policy: VolumePolicy
+    policy.openebs.io/version: 0.6.0
+  namespace: default
+data:
+  meta: |
+    {{- $isNodeAffinityRSIE := .Policy.NodeAffinityRequiredSchedIgnoredExec.value | default "false" -}}
+    {{- $nodeAffinityRSIEVal := fromYaml .Policy.NodeAffinityRequiredSchedIgnoredExec.value -}}
+    runNamespace: {{ .Volume.runNamespace }}
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    objectName: {{ .Volume.owner }}-rep
+    action: patch
+    queries:
+    - alias: objectName
+    patch:
+      type: strategic
+      pspec: |-
+        spec:
+          template:
+            spec:
+              affinity:
+                nodeAffinity:
+                  {{- if ne $isNodeAffinityRSIE "false" }}
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      {{- range $k, $v := $nodeAffinityRSIEVal }}
+                      - 
+                      {{- range $kk, $vv := $v }}
+                        {{ $kk }}: {{ $vv }}
+                      {{- end }}
+                      {{- end }}
+                      - key: kubernetes.io/hostname
+                        operator: In
+                        values:
+                        {{- if ne .TaskResult.vreplist.nodeNames "" }}
+                        {{- $nodeNamesMap := .TaskResult.vreplist.nodeNames | split " " }}
+                        {{- range $k, $v := $nodeNamesMap }}
+                        - {{ $v }}
+                        {{- end }}
+                        {{- end }}
+                  {{- else }}
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: kubernetes.io/hostname
+                        operator: In
+                        values:
+                        {{- if ne .TaskResult.vreplist.nodeNames "" }}
+                        {{- $nodeNamesMap := .TaskResult.vreplist.nodeNames | split " " }}
+                        {{- range $k, $v := $nodeNamesMap }}
+                        - {{ $v }}
+                        {{- end }}
+                        {{- end }}
+                  {{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: volume-controller-0.6.0
+  annotations:
+    openebs.io/policy: VolumePolicy
+    policy.openebs.io/version: 0.6.0
+  namespace: default
+data:
+  meta: |
+    runNamespace: {{ .Volume.runNamespace }}
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    action: put
+  task: |
+    {{- $isMonitor := .Policy.VolumeMonitor.enabled | default "true" | lower -}}
+    {{- $monitorVal := .Policy.VolumeMonitor.value | default "openebs/m-exporter:0.5.0" -}}
+    {{- $affinity := .TaskResult.vpvc.affinity -}}
+    {{- $affinityType := .TaskResult.vpvc.affinityType | default "soft" -}}
+    {{- $affinityTopology := .TaskResult.vpvc.affinityTopology | default "kubernetes.io/hostname" -}}
+    apiVersion: extensions/v1beta1
+    Kind: Deployment
+    metadata:
+      labels:
+        openebs.io/storage-engine-type: jiva
+        openebs/volume-provisioner: jiva
+        openebs/controller: jiva-controller
+        openebs.io/controller: jiva-controller
+        vsm: {{ .Volume.owner }}
+        openebs.io/pv: {{ .Volume.owner }}
+      annotations:
+        {{- if eq $isMonitor "true" }}
+        openebs.io/volume-monitor: "true"
+        {{- end}}
+        openebs.io/volume-type: jiva
+      name: {{ .Volume.owner }}-ctrl
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          {{- if eq $isMonitor "true" }}
+          monitoring: volume_exporter_prometheus
+          {{- end}}
+          openebs.io/controller: jiva-controller
+          openebs/controller: jiva-controller
+          openebs.io/pv: {{ .Volume.owner }}
+          vsm: {{ .Volume.owner }}
+      template:
+        metadata:
+          labels:
+            {{- if eq $isMonitor "true" }}
+            monitoring: volume_exporter_prometheus
+            {{- end}}
+            openebs.io/controller: jiva-controller
+            openebs/controller: jiva-controller
+            openebs.io/pv: {{ .Volume.owner }}
+            vsm: {{ .Volume.owner }}
+        spec:
+          {{- if ne $affinity "" }}
+          affinity:
+            podAffinity:
+              {{- if eq $affinityType "soft" }}
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: controller.openebs.io/affinity 
+                      operator: In 
+                      values:
+                      - {{ $affinity }} 
+                  topologyKey: {{ $affinityTopology }}
+              {{- else }}
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: controller.openebs.io/affinity
+                    operator: In
+                    values:
+                    - {{ $affinity }}
+                topologyKey: {{ $affinityTopology }}
+              {{- end }}
+          {{- end }}
+          containers:
+          - args:
+            - controller
+            - --frontend
+            - gotgt
+            - --clusterIP
+            - {{ .TaskResult.vsvc.serviceIP }}
+            - {{ .Volume.owner }}
+            command:
+            - launch
+            image: {{ .Policy.ControllerImage.value }}
+            name: {{ .Volume.owner }}-ctrl-con
+            ports:
+            - containerPort: 3260
+              protocol: TCP
+            - containerPort: 9501
+              protocol: TCP
+          {{- if eq $isMonitor "true" }}
+          - args:
+            - -c=http://127.0.0.1:9501
+            command:
+            - maya-volume-exporter
+            image: {{ $monitorVal }}
+            name: maya-volume-exporter
+            ports:
+            - containerPort: 9500
+              protocol: TCP
+          {{- end}}
+          tolerations:
+          - effect: NoExecute
+            key: node.alpha.kubernetes.io/notReady
+            operator: Exists
+            tolerationSeconds: 0
+          - effect: NoExecute
+            key: node.alpha.kubernetes.io/unreachable
+            operator: Exists
+            tolerationSeconds: 0
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: volume-replica-0.6.0
+  annotations:
+    openebs.io/policy: VolumePolicy
+    policy.openebs.io/version: 0.6.0
+  namespace: default
+data:
+  meta: |
+    runNamespace: {{ .Volume.runNamespace }}
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    action: put
+  task: |
+    {{- $isTaintTolerations := .Policy.TaintTolerations.value | default "false" -}}
+    {{- $taintTolerationsVal := fromYaml .Policy.TaintTolerations.value -}}
+    {{- $isEvictionTolerations := .Policy.EvictionTolerations.value | default "false" -}}
+    {{- $evictionTolerationsVal := fromYaml .Policy.EvictionTolerations.value -}}
+    {{- $isNodeAffinityRSIE := .Policy.NodeAffinityRequiredSchedIgnoredExec.value | default "false" -}}
+    {{- $nodeAffinityRSIEVal := fromYaml .Policy.NodeAffinityRequiredSchedIgnoredExec.value -}}
+    {{- $isNodeAffinityPSIE := .Policy.NodeAffinityPreferredSchedIgnoredExec.value | default "false" -}}
+    {{- $nodeAffinityPSIEVal := fromYaml .Policy.NodeAffinityPreferredSchedIgnoredExec.value -}}
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    metadata:
+      labels:
+        openebs.io/storage-engine-type: jiva
+        openebs/volume-provisioner: jiva
+        openebs/replica: jiva-replica
+        openebs.io/replica: jiva-replica
+        vsm: {{ .Volume.owner }}
+        openebs.io/pv: {{ .Volume.owner }}
+      name: {{ .Volume.owner }}-rep
+    spec:
+      replicas: {{ .Policy.ReplicaCount.value }}
+      selector:
+        matchLabels:
+          openebs/replica: jiva-replica
+          openebs.io/replica: jiva-replica
+          vsm: {{ .Volume.owner }}
+          openebs.io/pv: {{ .Volume.owner }}
+      template:
+        metadata:
+          labels:
+            openebs/replica: jiva-replica
+            openebs.io/replica: jiva-replica
+            vsm: {{ .Volume.owner }}
+            openebs.io/pv: {{ .Volume.owner }}
+        spec:
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchLabels:
+                    openebs/replica: jiva-replica
+                    openebs.io/replica: jiva-replica
+                    vsm: {{ .Volume.owner }}
+                    openebs.io/pv: {{ .Volume.owner }}
+                topologyKey: kubernetes.io/hostname
+            nodeAffinity:
+              {{- if ne $isNodeAffinityRSIE "false" }}
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  {{- range $k, $v := $nodeAffinityRSIEVal }}
+                  - 
+                  {{- range $kk, $vv := $v }}
+                    {{ $kk }}: {{ $vv }}
+                  {{- end }}
+                  {{- end }}
+              {{- end }}
+              {{- if ne $isNodeAffinityPSIE "false" }}
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExpressions:
+                  {{- range $k, $v := $nodeAffinityPSIEVal }}
+                  - 
+                  {{- range $kk, $vv := $v }}
+                    {{ $kk }}: {{ $vv }}
+                  {{- end }}
+                  {{- end }}
+              {{- end }}
+          containers:
+          - args:
+            - replica
+            - --frontendIP
+            - {{ .TaskResult.vsvc.serviceIP }}
+            - --size
+            - {{ .Volume.capacity }}
+            - /openebs
+            command:
+            - launch
+            image: {{ .Policy.ReplicaImage.value }}
+            name: {{ .Volume.owner }}-rep-con
+            ports:
+            - containerPort: 9502
+              protocol: TCP
+            - containerPort: 9503
+              protocol: TCP
+            - containerPort: 9504
+              protocol: TCP
+            volumeMounts:
+            - name: openebs
+              mountPath: /openebs
+          tolerations:
+          {{- if ne $isTaintTolerations "false" }}
+          {{- range $k, $v := $taintTolerationsVal }}
+          - 
+          {{- range $kk, $vv := $v }}
+            {{ $kk }}: {{ $vv }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- if ne $isEvictionTolerations "false" }}
+          {{- range $k, $v := $evictionTolerationsVal }}
+          - 
+          {{- range $kk, $vv := $v }}
+            {{ $kk }}: {{ $vv }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          volumes:
+          - name: openebs
+            hostPath:
+              path: {{ .TaskResult.vpath.storagePoolPath }}/{{ .Volume.owner }}


### PR DESCRIPTION
This commit provides the steps to make openebs volume replica
sticky to the node where this replica was originally placed.

This uses a maya api server code changes which has not been
checked-in. One can use openebs/m-apiserver:1310 to test
this replica pinning feature.

The detailed steps are present in the README file.

Signed-off-by: AmitKumarDas <amit.das@openebs.io>