### PR TITLE
Cstor pool pod tolerations

### DIFF
--- a/cstor-pool-pod-taints/cstor-pool-create-custom-cast.yaml
+++ b/cstor-pool-pod-taints/cstor-pool-create-custom-cast.yaml
@@ -1,0 +1,40 @@
+apiVersion: openebs.io/v1alpha1
+kind: CASTemplate
+metadata:
+  labels:
+    castName: cstor-pool-create-custom-0.8.0
+    version: 0.8.0
+  name: cstor-pool-create-custom-0.8.0
+spec:
+  defaultConfig:
+  - name: CstorPoolImage
+    value: quay.io/openebs/cstor-pool:0.8.0
+  - name: CstorPoolMgmtImage
+    value: quay.io/openebs/cstor-pool-mgmt:0.8.0
+  - name: HostPathType
+    value: DirectoryOrCreate
+  - name: SparseDir
+    value: /var/openebs/sparse
+  - name: RunNamespace
+    value: openebs
+  - name: ServiceAccountName
+    value: openebs-maya-operator
+  - name: PoolResourceRequests
+    value: none
+  - name: PoolResourceLimits
+    value: none
+  - name: AuxResourceLimits
+    value: none
+  - name: ResyncInterval
+    value: "30"
+  - name: Tolerations
+    value: none
+  run:
+    tasks:
+    - cstor-pool-create-getspcinfo-default-0.8.0
+    - cstor-pool-create-listnode-default-0.8.0
+    - cstor-pool-create-putcstorpoolcr-default-0.8.0
+    - cstor-pool-create-putcstorpooldeployment-custom-0.8.0
+    - cstor-pool-create-putstoragepoolcr-default-0.8.0
+    - cstor-pool-create-patchstoragepoolclaim-default-0.8.0
+  taskNamespace: openebs

--- a/cstor-pool-pod-taints/cstor-pool-deploy-custom-runtask.yaml
+++ b/cstor-pool-pod-taints/cstor-pool-deploy-custom-runtask.yaml
@@ -1,0 +1,162 @@
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  labels:
+    version: 0.8.0
+  name: cstor-pool-create-putcstorpooldeployment-custom-0.8.0
+  namespace: openebs
+spec:
+  meta: |
+    runNamespace: {{.Config.RunNamespace.value}}
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    action: put
+    id: putcstorpooldeployment
+    repeatWith:
+      resources:
+      {{- range $k, $v := .ListItems.nodeUidMap.nodeUid }}
+      - {{ $k }}
+      {{- end }}
+  post: |
+    {{- jsonpath .JsonResult "{.metadata.name}" | trim | addTo "putcstorpooldeployment.objectName" .TaskResult | noop -}}
+  task: |-
+    {{- $isTolerations := .Config.Tolerations.value | default "none" -}}
+    {{- $tolerationsVal := fromYaml .Config.Tolerations.value -}}
+    {{- $setResourceRequests := .Config.PoolResourceRequests.value | default "none" -}}
+    {{- $resourceRequestsVal := fromYaml .Config.PoolResourceRequests.value -}}
+    {{- $setResourceLimits := .Config.PoolResourceLimits.value | default "none" -}}
+    {{- $resourceLimitsVal := fromYaml .Config.PoolResourceLimits.value -}}
+    {{- $setAuxResourceLimits := .Config.AuxResourceLimits.value | default "none" -}}
+    {{- $auxResourceLimitsVal := fromYaml .Config.AuxResourceLimits.value -}}
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    metadata:
+      name: {{ pluck .ListItems.currentRepeatResource .ListItems.nodeUidMap.nodeUid |first | splitList " " | last}}
+      labels:
+        openebs.io/storage-pool-claim: {{.Storagepool.owner}}
+        openebs.io/cstor-pool: {{ pluck .ListItems.currentRepeatResource .ListItems.nodeUidMap.nodeUid |first | splitList " " | last}}
+        app: cstor-pool
+        openebs.io/version: {{ .CAST.version }}
+        openebs.io/cas-template-name: {{ .CAST.castName }}
+    spec:
+      strategy:
+        type: Recreate
+      replicas: 1
+      selector:
+        matchLabels:
+          app: cstor-pool
+      template:
+        metadata:
+          labels:
+            app: cstor-pool
+            openebs.io/storage-pool-claim: {{.Storagepool.owner}}
+        spec:
+          serviceAccountName: {{ .Config.ServiceAccountName.value }}
+          nodeSelector:
+            kubernetes.io/hostname: {{ .ListItems.currentRepeatResource}}
+          containers:
+          - name: cstor-pool
+            image: {{ .Config.CstorPoolImage.value }}
+            resources:
+              {{- if ne $setResourceLimits "none" }}
+              limits:
+              {{- range $rKey, $rLimit := $resourceLimitsVal }}
+                {{ $rKey }}: {{ $rLimit }}
+              {{- end }}
+              {{- end }}
+              {{- if ne $setResourceRequests "none" }}
+              requests:
+              {{- range $rKey, $rReq := $resourceRequestsVal }}
+                {{ $rKey }}: {{ $rReq }}
+              {{- end }}
+              {{- end }}
+            ports:
+            - containerPort: 12000
+              protocol: TCP
+            - containerPort: 3233
+              protocol: TCP
+            - containerPort: 3232
+              protocol: TCP
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - name: device
+              mountPath: /dev
+            - name: tmp
+              mountPath: /tmp
+            - name: sparse
+              mountPath: {{ .Config.SparseDir.value }}
+            - name: udev
+              mountPath: /run/udev
+              # To avoid clash between terminating and restarting pod
+              # in case older zrepl gets deleted faster, we keep initial delay
+            lifecycle:
+              postStart:
+                 exec:
+                    command: ["/bin/sh", "-c", "sleep 2"]
+          - name: cstor-pool-mgmt
+            image: {{ .Config.CstorPoolMgmtImage.value }}
+            {{- if ne $setAuxResourceLimits "none" }}
+            resources:
+              limits:
+              {{- range $rKey, $rLimit := $auxResourceLimitsVal }}
+                {{ $rKey }}: {{ $rLimit }}
+              {{- end }}
+            {{- end }}
+            ports:
+            - containerPort: 9500
+              protocol: TCP
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - name: device
+              mountPath: /dev
+            - name: tmp
+              mountPath: /tmp
+            - name: sparse
+              mountPath: {{ .Config.SparseDir.value }}
+            - name: udev
+              mountPath: /run/udev
+            env:
+              # OPENEBS_IO_CSTOR_ID env has UID of cStorPool CR.
+            - name: OPENEBS_IO_CSTOR_ID
+              value: {{ pluck .ListItems.currentRepeatResource .ListItems.nodeUidMap.nodeUid |first | splitList " " | first}}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: RESYNC_INTERVAL
+              value: {{ .Config.ResyncInterval.value }}
+          tolerations:
+          {{- if ne $isTolerations "none" }}
+          {{- range $k, $v := $tolerationsVal }}
+          -
+          {{- range $kk, $vv := $v }}
+            {{ $kk }}: {{ $vv }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          volumes:
+          - name: device
+            hostPath:
+              # directory location on host
+              path: /dev
+              # this field is optional
+              type: Directory
+          - name: tmp
+            hostPath:
+              # From host, dir called /var/openebs/shared-<uid> is created to avoid clash if two replicas run on same node.
+              path: /var/openebs/shared-{{.Storagepool.owner}}
+              type: {{ .Config.HostPathType.value }}
+          - name: sparse
+            hostPath:
+              path: {{ .Config.SparseDir.value }}
+              type: {{ .Config.HostPathType.value }}
+          - name: udev
+            hostPath:
+              path: /run/udev
+              type: Directory

--- a/cstor-pool-pod-taints/spc.yaml
+++ b/cstor-pool-pod-taints/spc.yaml
@@ -1,0 +1,45 @@
+apiVersion: openebs.io/v1alpha1
+kind: StoragePoolClaim
+metadata:
+  name: cstor-sparse-pool
+  annotations:
+    cas.openebs.io/create-pool-template: cstor-pool-create-custom-0.8.0
+    cas.openebs.io/config: |
+      #For default sparse pool set the limit at 2Gi to safegaurd 
+      # cstor pool from consuming more memory and causing the node 
+      # to get into memory pressure condition. By default K8s will set the 
+      # Requests to the same value as Limits. For example, when Limit is
+      # set to 2Gi, the pool could get stuck in pending schedule state,
+      # if node doesn't have Requested (2Gi) memory. 
+      # Hence setting the Requests to a minimum (0.5Gi). 
+      - name: PoolResourceRequests
+        value: |-
+            memory: 0.5Gi
+            cpu: 100m
+      - name: PoolResourceLimits
+        value: |-
+            memory: 2Gi
+            cpu: 500m
+      # Put your required tolerations here
+      # The key in tolerations ( e.g. t1, t2 ) cannot be same for different tolerations
+      - name: Tolerations
+        value: |-
+          t1:
+            effect: NoSchedule
+            key: testExists
+            operator: Exists
+          t2:
+            effect: NoSchedule
+            key: testEqual
+            operator: Equal
+            value: "testEuqalValue"
+      #- name: AuxResourceLimits
+      #  value: |-
+      #      memory: 1Gi
+      #      cpu: 100m
+spec:
+  name: cstor-sparse-pool
+  type: sparse
+  maxPools: 3
+  poolSpec:
+    poolType: striped


### PR DESCRIPTION
### What this PR does
This explains the procedure to apply custom policies to extend openebs default scheduling mechanism. Here, it showcases customization of openebs storage pool placements. Following the steps mentioned below will let the end user schedule storage pool PODs on nodes dedicated for storage.

### Steps
- Apply the CASTemplate (new)
  - https://raw.githubusercontent.com/openebs/community/a40ea5c9abe0c6d6b01f458153ac22681b74bf4c/cstor-pool-pod-taints/cstor-pool-create-custom-cast.yaml
- Apply the RunTask (new)
  - https://raw.githubusercontent.com/openebs/community/a40ea5c9abe0c6d6b01f458153ac22681b74bf4c/cstor-pool-pod-taints/cstor-pool-deploy-custom-runtask.yaml
- Edit the SPC custom resource (update)
  - Set the name of cas template (refer first link above) as a annotaion
  - Set the toleration policy in cas.config
  - A sample reference:
    - https://github.com/openebs/community/blob/a40ea5c9abe0c6d6b01f458153ac22681b74bf4c/cstor-pool-pod-taints/spc.yaml

**NOTE: For OpenEBS componenets e.g. maya-apiserver, provisioner etc tolerations will need to be added separately via the operator yaml or helm or updating the deployments.**