### PR TITLE
docs (roles): Definition and processes, esp maintainers

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,6 +1,6 @@
 # OpenEBS Umbrella Project Governance
 > [!Important]
-> OpenEBS is an "umbrella" project,  composed as a federation of individual sub projects (repositories). The umbrella project, every sub project, repository/repo and file in the OpenEBS organization adopts and follows the same set of umbrella policies in the OpenEBS Community repo. This is the Umbrella Project Governance policy.
+> OpenEBS is an "umbrella" project,  composed as a federation of individual sub projects (repositories). The umbrella project, every sub project, repository/repo and file in the OpenEBS organization adopts and follows the same set of umbrella policies located in the OpenEBS Community repo. This is the Umbrella Project Governance policy.
 <BR>
 
 ## Key references:
@@ -9,7 +9,7 @@ Please familiarize yourself with our [Project Vision](./VISION.md) and [Contribu
 ---
 <BR>
 
-The **OpenEBS project** is managed on a daily basis by a senior governance & leadership team, that consists of the following OpenEBS ```Admins```, ```Maintainers``` and ```Senior leaders```. Currently the team is...
+The **OpenEBS project** is managed on a daily basis by a senior governance & leadership team, that consists of the following OpenEBS ```Admins``` and ```Maintainers.``` Currently the team is...
 > |   |   |   |    |
 > | :--- | :--- | :--- | :--- |
 > | [Vishnu Attur](https://www.linkedin.com/in/vishnu-attur-5309a333/ "Bengaluru, Karnataka, India (GMT+5:30) Timezone")| :octocat: <kbd>**[@avishnu](https://github.com/avishnu "Vishnu Govind Attur")**</kbd> | ![](/images/flags/de_je/in.png) | <kbd>**Admin**</kbd>, ```Maintainer``` |
@@ -21,84 +21,90 @@ The **OpenEBS project** is managed on a daily basis by a senior governance & lea
 
 <BR>
 
-## Org Admin, Maintainers, Contributors and Adopters
+## Admin, Maintainers, Contributors and Adopters
 
-The OpenEBS project has four core roles. All project members operate in one (or more) of these roles:
+The OpenEBS project has five core roles. All project members operate in one (or more) of these roles:
 <BR>
 
-| Level | Member type | Example description, scope and role |
+| Level | Role | Responsibilities |
 | :---  | :--- | :--- |
-| 1     | **Org Admin** | Administer organization in GitHub, add/subtract admins, invite members, manage org and repo integrations. |
-| 2     | **Maintainers** | Vote, Develop roadmap, contribution guidelines; Review, Approve/Reject, Merge, Manage repos. Maintainers are elected or removed by the current maintainers. A maintainer’s authority applies to the OpenEBS organization and every sub-project in the organization; unless they have been appointed as a [special maintainer](#special-projects-and-special-maintainers) |
-| 3     | **Special**<BR>**Maintainers**| Act as a voting maintainer for specific projects, sub-projects and repo's as defined by the Maintainers |
-| 3     | **Contributors** | Contribute code, test, document the project. A contributor’s authority applies to one or more sub projects. |
-| 4     | **Adopters** | Use the OpenEBS product, with or without contributing to the project. An adopter has authority to raise issues, participate in discussions on sub projects within a public forum. |
+| 1     | **Admin** | Administer organization in GitHub. Add/subtract admins, invite members, manage org and repo integrations. |
+| 2     | **Maintainer** | Vote, Develop roadmap, contribution guidelines; Review, Approve/Reject, Merge, Manage repos. Maintainers are elected or removed by the current maintainers. A maintainer has authority over the OpenEBS umbrella project: the organization and every proejct, sub-project and repo within the organization.|
+| 3     | **Special**<BR>**Maintainer**| Have special expertize in a particular domain. The domain may be a project, sub-project, repo or other responsibility as defined by the Maintainers. The maintainers grant a special maintainer a set of authorities and responsibilities for the domain. A special maintainer is expected to join maintainer and community meetings when required. A special maintainer has no responsibilities for the umbrella project, or projects outside their domain.|
+| 4     | **Contributor** | Contribute code, test, document the project. A contributor’s authority applies to one or more sub projects. |
+| 5     | **Adopters** | Use the OpenEBS product, with or without contributing to the project. An adopter has authority to raise issues, participate in discussions on sub projects within a public forum. |
 <BR>
 
 These roles are described in more detail below:
 
-### Org Admin
-The org admins are a group that primarily perform the non-code-related Github tasks such as updating permissions, configuring integrations and other administrative tasks. The admins are informally appointed by the maintainers or by other org admins.
+### Admin
+Admins perform the non-code-related Github tasks such as updating permissions, configuring integrations and other administrative tasks. Admins are informally appointed and removed by the maintainers, CNCF or other Admins.
 <BR>
 
-### Maintainers
-Maintainers are an elected group that share responsibility in the OpenEBS project success. They have made a long-term, recurring time investment to improve the project, and spend their time doing what needs to be done, not necessarily what is the most interesting or fun. Maintainers of the project are people the community can depend on and trust to make decisions in the best interest of the project. Anyone wanting to become a maintainer is expected to be deeply involved in contributing code, pull request review, and triage of issues in the project for more than three months.
+### Maintainer
+Maintainers are an elected group that share responsibility in the OpenEBS project success. They make a long-term, full-time (or mostly full-time) investment to improve and govern the project. Maintainers spend their time doing what needs to be done. Maintainers of the project are people the community can depend on and trust to make decisions in the best interest of the project. **Anyone can become a maintainer.**
 
-Maintainers have authority over all sub projects within the OpenEBS organization, with responsibility for:
+Maintainers have authority over all projects, sub projects and repos within the OpenEBS organization, with responsibility for:
 
 * Project roadmap
 * Reviewing, approving and denying contributions
 * Maintaining coding, testing and documentation standards
 * Providing support and community engagement
-* Administration of the OpenEBS GitHub organization and repositories
+* Project management and governance
 * Activities that move the project towards graduation status
 
 #### Becoming a Maintainer
-To become a Maintainer you need to demonstrate the following:
+To become a Maintainer you need to demonstrate committment to the OpenEBS project. A typical committment is:
 
-* commitment to the OpenEBS project:
-    * Participate in discussions, contributions, code and documentation reviews for three months or more
-    * Perform reviews of and contribute to non-trivial pull requests
-    * Demonstrate alignment with the project vision and roadmap
-* ability to write quality code and/or documentation
-* ability to collaborate with the team
-* understanding of how the team works (policies, processes for testing and code review, etc)
-* understanding of the project's code base and coding and documentation style
+* Participate in discussions, contributions, code and documentation reviews for three months or more
+* Perform reviews of and contribute to non-trivial pull requests
+* Demonstrate alignment with the project vision and roadmap
+* Ability to write quality code and/or documentation
+* Ability to collaborate with the team
+* Understanding of how the team works (policies, processes for testing and code review, etc)
+* Understanding of the project's code base and coding and documentation style
 
-A new Maintainer is nominated by an existing maintainer, a public vote is undertaken, and a 50% vote of existing Maintainers (rounded off to the ceiling) approves the application. A new maintainer’s nomination will be evaluated without prejudice to employer or demographics.
+The maintainers work full-time (or mostly full-time) in the project. Every new maintainer is expected to also make the same time committment, to have availability and repsonsiveness when working with other maintainers and be responsive to community issues.
 
-Maintainers who are selected will be granted necessary GitHub rights, and invited to the private maintainer mailing list.
+Process for assigning a new maintainer:
+1. Candidate is nominated by an existing maintainer at a weekly maintainers meeting
+2. The candidate meets with the maintainers
+3. Maintainers vote (in private), the maintainer is appointed if 50% or more of the organization maintainers approve of the appointment
+4. If approved, the approval is recorded in the maintainer meeting minutes, the new maintainer will be granted necessary GitHub rights, and invited to the private maintainer mailing list and meetings.
 
+#### Remaining a Maintainer
+Maintainers are expected to operate with a full-time (or mostly full-time) committment, availability and participation in the project.
+If a maintainer can no longer meet these committments, they are expected to consult with the other maintainers and either take a sabbatical from maintainership, or resign as a maintainer. It is the responsibility of all maintainers to ensure the maintainer group operates with the same level of committment.
 
 #### Removing a Maintainer
-Maintainers may resign at any time if they feel that they will not be able to continue fulfilling their project duties. Maintainers may also be removed after being inactive, failure to fulfill their Maintainer responsibilities, violating the Code of Conduct, or other reasons.
+Maintainers may resign at any time. A maintainer may request a time-bound sabbatical (during which they a released from all duties and voting rights). 
+The maintainers may also vote to remove a maintainer, if they feel the person will not be able to continue fulfilling their project duties.
 
-A Maintainer may be removed at any time by a ⅔ vote of the remaining maintainers, rounded off to the ceiling.
+The process for removing a maintainer:
+1. Maintainers attempt to contact the maintainer privately. Depending on the circumstances, the maintainer may be requested to re-assume their project committment, requested to resign, or advised a vote will be made to remove them from the project
+2. If the maintainer chooses to resign, a record is made in the maintainer meeting minutes
+3. The remaining maintainers may choose to vote to remove the maintainer. The action is approved if 66% or more of the remaining maintainers vote to remove the maintainer. A record of the vote is made in the maintainer meeting minutes
+4. When a maintainer is removed: GitHub admin rights, permissions and mailing list membership are also immediately removed.
 
-### Contributors
-OpenEBS is a very welcoming community and is eager to onboard and help anyone from the OpenSource community to contribute to the project. To facilitate onboarding of the community members, OpenEBS contributors participate in Hacktoberfest events and are responsive on the slack, community meetings and github.
+### Special Maintainer
+Special Maintainers have expertise and authority in a specific domain. Special maintainers are assigned or removed by the maintainers, by vote with 50% approval, and given scoped authority for their domain. For example:
+* Special maintainer for one or more sub projects (typically where the individual has specialist knowledge for a discrete area of the project), the special maintainer shares maintainership of the project with the maintainers
+* Special maintainer for a task or responsibility
+
+Special maintainers are enabled to act indepedently. The do not have responsibilities within the umbrella project. They do not have voting rights over the umbrella project. They are expected to participate with the community, They are not expected to participate in maintainer meetings, unless requested.
+
+Special Maintainers are listed in the SPECIAL_MAINTAINERS document.
+
+### Contributor
+OpenEBS is a very welcoming community and is eager to onboard and help anyone from the open source community to contribute to the project. To facilitate onboarding of the community members, OpenEBS contributors participate in Hacktoberfest events and are responsive on the slack, community meetings and github.
 
 Any individual with intent to contribute to open source in general or fix a specific issue they are having the OpenEBS project can contribute. If anyone is looking for ideas for contributing, the open issue backlog maintained under the OpenEBS GitHub projects is a great place to start.
 
 A maintainer may assign a regular contributor write access to the GitHub project to allow them to directly request other organization members as reviewers for their PRs and to help them being added as reviewers for contributions coming from other contributors or OpenEBS organization members. A maintainer may also revoke the write access to the GitHub project.
 
 
-### Adopters
+### Adopter
 OpenEBS welcomes people who simply want to Adopt the OpenEBS product, and welcomes them as part of our community. Adopters may use the OpenEBS product as they wish, contribute ideas or code, or create a fork of the code.
-
-
-## Special Projects and Special Maintainers
-All sub projects within the OpenEBS organization abide by the common umbrella governance and policies, and a maintainer has authority over all sub projects, with these exceptions.
-
-The OpenEBS maintainers may elect:
-
-* A “special maintainer” for one or more sub projects (typically where the individual has specialist knowledge for a discrete area of the project)
-* A “special project” that operates with deviation from the common umbrella governance and rules. The deviations are listed in the project’s README.md.
-
-Special projects and special maintainers are elected and removed by a Maintainers vote (requiring 50% for election, and ⅔ for removal).
-
-Special Projects and Special Maintainers are listed in the section “Appendix 1: Special Projects and Special Maintainers”
-
 
 ## Adding and Removing Sub Projects
 The maintainers may add or remove sub projects or repositories. The maintainers take a conservative policy towards changing the sub projects: a new sub project must have a long term purpose that is distinct from existing sub projects; removed sub projects must be demonstrated to have outlived their purpose or have become unmaintainable.
@@ -108,15 +114,9 @@ When a sub project is removed, it is moved as-is to the OpenEBS-archive organiza
 
 ## How are decisions made?
 [See CONTRIBUTING guidelines and rules doc](./CONTRIBUTING.md)
-```ruby
-Also see: MAINTAINERS file
-```
 
 ## Conflict Resolution
 If you have a technical dispute that you feel has reached an impasse with a subset of the community, any contributor may open an issue, specifically calling for a resolution vote of the current maintainers to resolve the dispute. The same voting quorums required (2/3) for removing maintainers will apply to conflict resolution.
 
 ## Modifying this document
-Changes to this policy and any supporting documents must be agreed and approved by 2/3 of the Maintainers either by vote, or by review and approval of a PR on the document.
-
-## Appendix 1: Special Projects and Special Maintainers
-* Ed Robinson, Special Maintainer for OpenEBS/Community repo
+Changes to this policy and any supporting documents must be agreed and approved by 66% of the Maintainers either by vote, or by review and approval of a PR on the document.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -21,9 +21,9 @@ The **OpenEBS project** is managed on a daily basis by a senior governance & lea
 
 <BR>
 
-## Admin, Maintainers, Contributors and Adopters
+## Admins, Maintainers, Contributors and Adopters
 
-The OpenEBS project has five core roles. All project members operate in one (or more) of these roles:
+The OpenEBS project has five roles. All project members operate in one (or more) of these roles:
 <BR>
 
 | Level | Role | Responsibilities |
@@ -32,7 +32,7 @@ The OpenEBS project has five core roles. All project members operate in one (or 
 | 2     | **Maintainer** | Vote, Develop roadmap, contribution guidelines; Review, Approve/Reject, Merge, Manage repos. Maintainers are elected or removed by the current maintainers. A maintainer has authority over the OpenEBS umbrella project: the organization and every proejct, sub-project and repo within the organization.|
 | 3     | **Special**<BR>**Maintainer**| Have special expertize in a particular domain. The domain may be a project, sub-project, repo or other responsibility as defined by the Maintainers. The maintainers grant a special maintainer a set of authorities and responsibilities for the domain. A special maintainer is expected to join maintainer and community meetings when required. A special maintainer has no responsibilities for the umbrella project, or projects outside their domain.|
 | 4     | **Contributor** | Contribute code, test, document the project. A contributor’s authority applies to one or more sub projects. |
-| 5     | **Adopters** | Use the OpenEBS product, with or without contributing to the project. An adopter has authority to raise issues, participate in discussions on sub projects within a public forum. |
+| 5     | **Adopter** | Use the OpenEBS product, with or without contributing to the project. An adopter has authority to raise issues, participate in discussions on sub projects within a public forum. |
 <BR>
 
 These roles are described in more detail below:
@@ -42,7 +42,7 @@ Admins perform the non-code-related Github tasks such as updating permissions, c
 <BR>
 
 ### Maintainer
-Maintainers are an elected group that share responsibility in the OpenEBS project success. They make a long-term, full-time (or mostly full-time) investment to improve and govern the project. Maintainers spend their time doing what needs to be done. Maintainers of the project are people the community can depend on and trust to make decisions in the best interest of the project. **Anyone can become a maintainer.**
+Maintainers are an elected group that share responsibility in the OpenEBS project success. They make a long-term, dedicated commitment to improve and govern the project. Maintainers are responsive, available and deliver results to schedule. Because of this commitment, many maintainers are full-time (or majority-of-time) on the OpenEBS project, although this is not a requirement. Maintainers get stuff done. Maintainers work for the OpenEBS community. A maintainer is someone the community can depend on and trust to make decisions in the best interest of the project. **Anyone can become a maintainer.**
 
 Maintainers have authority over all projects, sub projects and repos within the OpenEBS organization, with responsibility for:
 
@@ -51,10 +51,11 @@ Maintainers have authority over all projects, sub projects and repos within the 
 * Maintaining coding, testing and documentation standards
 * Providing support and community engagement
 * Project management and governance
+* Adding/removing maintainers, admins and special maintainers
 * Activities that move the project towards graduation status
 
 #### Becoming a Maintainer
-To become a Maintainer you need to demonstrate committment to the OpenEBS project. A typical committment is:
+To become a Maintainer you need to demonstrate continued committment, responsiveness and availability to the OpenEBS project. For example:
 
 * Participate in discussions, contributions, code and documentation reviews for three months or more
 * Perform reviews of and contribute to non-trivial pull requests
@@ -64,12 +65,12 @@ To become a Maintainer you need to demonstrate committment to the OpenEBS projec
 * Understanding of how the team works (policies, processes for testing and code review, etc)
 * Understanding of the project's code base and coding and documentation style
 
-The maintainers work full-time (or mostly full-time) in the project. Every new maintainer is expected to also make the same time committment, to have availability and repsonsiveness when working with other maintainers and be responsive to community issues.
+Mainy maintainers work full-time (or majority-of-time) in the project. Every new maintainer is expected to have the same availability, committment and responsiveness as the existing maintainers.
 
 Process for assigning a new maintainer:
 1. Candidate is nominated by an existing maintainer at a weekly maintainers meeting
 2. The candidate meets with the maintainers
-3. Maintainers vote (in private), the maintainer is appointed if 50% or more of the organization maintainers approve of the appointment
+3. Maintainers vote (in private), the candidate is appointed if 50% or more of the organization maintainers approve of the appointment
 4. If approved, the approval is recorded in the maintainer meeting minutes, the new maintainer will be granted necessary GitHub rights, and invited to the private maintainer mailing list and meetings.
 
 #### Remaining a Maintainer
@@ -82,18 +83,25 @@ The maintainers may also vote to remove a maintainer, if they feel the person wi
 
 The process for removing a maintainer:
 1. Maintainers attempt to contact the maintainer privately. Depending on the circumstances, the maintainer may be requested to re-assume their project committment, requested to resign, or advised a vote will be made to remove them from the project
-2. If the maintainer chooses to resign, a record is made in the maintainer meeting minutes
+2. If the maintainer chooses to resign, the resignation is recorded in the maintainer meeting minutes
 3. The remaining maintainers may choose to vote to remove the maintainer. The action is approved if 66% or more of the remaining maintainers vote to remove the maintainer. A record of the vote is made in the maintainer meeting minutes
 4. When a maintainer is removed: GitHub admin rights, permissions and mailing list membership are also immediately removed.
 
 ### Special Maintainer
-Special Maintainers have expertise and authority in a specific domain. Special maintainers are assigned or removed by the maintainers, by vote with 50% approval, and given scoped authority for their domain. For example:
-* Special maintainer for one or more sub projects (typically where the individual has specialist knowledge for a discrete area of the project), the special maintainer shares maintainership of the project with the maintainers
-* Special maintainer for a task or responsibility
+A Special Maintainer is appointed by the maintainers to recognize a contributor with expertise and authority in a specific domain. Special Maintainers are appointed to have elevated privilege, authority and specific responsibilities. The special maintainer role is part of the OpenEBS contributor ladder, and is the primary path from contributor to maintainer. Special maintainers are assigned or removed by the maintainers, by vote with 50% approval, and their role 
+and resposibilites are scoped. A person can have one or more Special Maintainer repsonsibilities
+
+OpenEBS has appointed or will appoint special maintainers for the following roles:
+* CNCF Liaison. To be a primary point of contact between the project and CNCF
+* Project manager. To keep track of tasks, and make sure maintainers, special maintainers and contributors deliver on time
+* Sub-project maintainer. To own specific project (tpyically an engine), and to ensure coding standards, issue resolution, documentation, roadmap is in compliance for the sub-project
+* Documentation manager. To oversee and help produce the techdocs and community documentation
+* Test manager. To oversee and coordinate test coverage
+* Special projects. Other projects that come up from time-to-time
 
 Special maintainers are enabled to act indepedently. The do not have responsibilities within the umbrella project. They do not have voting rights over the umbrella project. They are expected to participate with the community, They are not expected to participate in maintainer meetings, unless requested.
 
-Special Maintainers are listed in the SPECIAL_MAINTAINERS document.
+Special Maintainers are listed in the [MAINTAINERS](./MAINTAINERS) document.
 
 ### Contributor
 OpenEBS is a very welcoming community and is eager to onboard and help anyone from the open source community to contribute to the project. To facilitate onboarding of the community members, OpenEBS contributors participate in Hacktoberfest events and are responsive on the slack, community meetings and github.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -29,8 +29,8 @@ The OpenEBS project has five roles. All project members operate in one (or more)
 | Level | Role | Responsibilities |
 | :---  | :--- | :--- |
 | 1     | **Admin** | Administer organization in GitHub. Add/subtract admins, invite members, manage org and repo integrations. |
-| 2     | **Maintainer** | Vote, Develop roadmap, contribution guidelines; Review, Approve/Reject, Merge, Manage repos. Maintainers are elected or removed by the current maintainers. A maintainer has authority over the OpenEBS umbrella project: the organization and every proejct, sub-project and repo within the organization.|
-| 3     | **Special**<BR>**Maintainer**| Have special expertize in a particular domain. The domain may be a project, sub-project, repo or other responsibility as defined by the Maintainers. The maintainers grant a special maintainer a set of authorities and responsibilities for the domain. A special maintainer is expected to join maintainer and community meetings when required. A special maintainer has no responsibilities for the umbrella project, or projects outside their domain.|
+| 2     | **Maintainer** | Vote, Develop roadmap, contribution guidelines; Review, Approve/Reject, Merge, Manage repos. Maintainers are elected or removed by the current maintainers. A maintainer has authority over the OpenEBS umbrella project: the organization and every project, sub-project and repo within the organization.|
+| 3     | **Special**<BR>**Maintainer**| Have special expertise in a particular domain. The domain may be a project, sub-project, repo or other responsibility as defined by the Maintainers. The maintainers grant a special maintainer a set of authorities and responsibilities for the domain. A special maintainer is expected to join maintainer and community meetings when required. A special maintainer has no responsibilities for the umbrella project, or projects outside their domain.|
 | 4     | **Contributor** | Contribute code, test, document the project. A contributor’s authority applies to one or more sub projects. |
 | 5     | **Adopter** | Use the OpenEBS product, with or without contributing to the project. An adopter has authority to raise issues, participate in discussions on sub projects within a public forum. |
 <BR>
@@ -55,7 +55,7 @@ Maintainers have authority over all projects, sub projects and repos within the 
 * Activities that move the project towards graduation status
 
 #### Becoming a Maintainer
-To become a Maintainer you need to demonstrate continued committment, responsiveness and availability to the OpenEBS project. For example:
+To become a Maintainer you need to demonstrate continued commitment, responsiveness and availability to the OpenEBS project. For example:
 
 * Participate in discussions, contributions, code and documentation reviews for three months or more
 * Perform reviews of and contribute to non-trivial pull requests
@@ -65,7 +65,7 @@ To become a Maintainer you need to demonstrate continued committment, responsive
 * Understanding of how the team works (policies, processes for testing and code review, etc)
 * Understanding of the project's code base and coding and documentation style
 
-Mainy maintainers work full-time (or majority-of-time) in the project. Every new maintainer is expected to have the same availability, committment and responsiveness as the existing maintainers.
+Many maintainers work full-time (or majority-of-time) in the project. Every new maintainer is expected to have the same availability, commitment and responsiveness as the existing maintainers.
 
 Process for assigning a new maintainer:
 1. Candidate is nominated by an existing maintainer at a weekly maintainers meeting
@@ -74,32 +74,32 @@ Process for assigning a new maintainer:
 4. If approved, the approval is recorded in the maintainer meeting minutes, the new maintainer will be granted necessary GitHub rights, and invited to the private maintainer mailing list and meetings.
 
 #### Remaining a Maintainer
-Maintainers are expected to operate with a full-time (or mostly full-time) committment, availability and participation in the project.
-If a maintainer can no longer meet these committments, they are expected to consult with the other maintainers and either take a sabbatical from maintainership, or resign as a maintainer. It is the responsibility of all maintainers to ensure the maintainer group operates with the same level of committment.
+Maintainers are expected to operate with a full-time (or mostly full-time) commitment, availability and participation in the project.
+If a maintainer can no longer meet these commitments, they are expected to consult with the other maintainers and either take a sabbatical from maintainership, or resign as a maintainer. It is the responsibility of all maintainers to ensure the maintainer group operates with the same level of commitment.
 
 #### Removing a Maintainer
 Maintainers may resign at any time. A maintainer may request a time-bound sabbatical (during which they a released from all duties and voting rights). 
 The maintainers may also vote to remove a maintainer, if they feel the person will not be able to continue fulfilling their project duties.
 
 The process for removing a maintainer:
-1. Maintainers attempt to contact the maintainer privately. Depending on the circumstances, the maintainer may be requested to re-assume their project committment, requested to resign, or advised a vote will be made to remove them from the project
+1. Maintainers attempt to contact the maintainer privately. Depending on the circumstances, the maintainer may be requested to re-assume their project commitment, requested to resign, or advised a vote will be made to remove them from the project
 2. If the maintainer chooses to resign, the resignation is recorded in the maintainer meeting minutes
 3. The remaining maintainers may choose to vote to remove the maintainer. The action is approved if 66% or more of the remaining maintainers vote to remove the maintainer. A record of the vote is made in the maintainer meeting minutes
 4. When a maintainer is removed: GitHub admin rights, permissions and mailing list membership are also immediately removed.
 
 ### Special Maintainer
 A Special Maintainer is appointed by the maintainers to recognize a contributor with expertise and authority in a specific domain. Special Maintainers are appointed to have elevated privilege, authority and specific responsibilities. The special maintainer role is part of the OpenEBS contributor ladder, and is the primary path from contributor to maintainer. Special maintainers are assigned or removed by the maintainers, by vote with 50% approval, and their role 
-and resposibilites are scoped. A person can have one or more Special Maintainer repsonsibilities
+and responsibilities are scoped. A person can have one or more Special Maintainer responsibilities
 
 OpenEBS has appointed or will appoint special maintainers for the following roles:
 * CNCF Liaison. To be a primary point of contact between the project and CNCF
 * Project manager. To keep track of tasks, and make sure maintainers, special maintainers and contributors deliver on time
-* Sub-project maintainer. To own specific project (tpyically an engine), and to ensure coding standards, issue resolution, documentation, roadmap is in compliance for the sub-project
+* Sub-project maintainer. To own specific project (typically an engine), and to ensure coding standards, issue resolution, documentation, roadmap is in compliance for the sub-project
 * Documentation manager. To oversee and help produce the techdocs and community documentation
 * Test manager. To oversee and coordinate test coverage
 * Special projects. Other projects that come up from time-to-time
 
-Special maintainers are enabled to act indepedently. The do not have responsibilities within the umbrella project. They do not have voting rights over the umbrella project. They are expected to participate with the community, They are not expected to participate in maintainer meetings, unless requested.
+Special maintainers are enabled to act independently. The do not have responsibilities within the umbrella project. They do not have voting rights over the umbrella project. They are expected to participate with the community, They are not expected to participate in maintainer meetings, unless requested.
 
 Special Maintainers are listed in the [MAINTAINERS](./MAINTAINERS) document.
 


### PR DESCRIPTION
For in-person review in the maintainers meeting.
added more definition around roles, aligned some of the terms, added more process around maintainers

Signed-off-by: Ed Robinson <ed.robinson@gmail.com>