### PR TITLE
docs: drop mehran as rawfile sub-project maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -36,6 +36,5 @@ projects, sub-projects and forks contained within and under the entire OpenEBS p
 
 | Name                                                     | GitHub ID                                                   | Affiliation       | Sub-Projects      |
 |----------------------------------------------------------|-------------------------------------------------------------|-------------------|-------------------|
-| Mehran Kholdi                                            | [@semekh](https://github.com/semekh)                        | -                 | LocalPv-Rawfile   |
 
 <BR>


### PR DESCRIPTION
Mehran has stated he no longer has time to maintainer the rawfile sub-project. 
He's also not been responding to any emails since. 
We've also set a 1-month public deadline, and that has now elapsed.