### PR TITLE
docs: add community meeting event links

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,14 @@ We are a community of innovative Data Storage engineers that contribute to this 
 This Community repository is the ```central location``` for project info and files like our governance, contribution, code of conduct, security and vision for the OpenEBS organization laid out by the Maintainers. You'll also find a [Top level Issues List](https://github.com/openebs/openebs/issues) for Organization related issues that span across products/projects. We also provide a [main Discussions forum](https://github.com/openebs/openebs/discussions) where **```everyone```** can collaborate and discuss anything.
 
 - Homepage: [openebs.io](https://openebs.io/)
-- Mailing list: openebs-team@googlegroups.com
-- Slack: [slack](https://kubernetes.slack.com/messages/openebs)
-- Twitter: [openebs](https://twitter.com/intent/follow?screen_name=openebs)
-- Community Meeting: OpenEBS holds a monthly community meeting via Zoom on the last Thursday of the month, at 14:00 UTC. [Meeting Link](https://us05web.zoom.us/j/87535654586?pwd=CigbXigJPn38USc6Vuzt7qSVFoO79X.1)
+- Maintainers' email: openebs-team@googlegroups.com
+- Slack:
+  - [#openebs](https://kubernetes.slack.com/messages/openebs)
+  - [#openebs-dev](https://kubernetes.slack.com/messages/openebs-dev)
+- Twitter: [@openebs](https://twitter.com/intent/follow?screen_name=openebs)
+- Community Meeting: OpenEBS holds a monthly [community meeting](https://us05web.zoom.us/j/87535654586?pwd=CigbXigJPn38USc6Vuzt7qSVFoO79X.1) via Zoom on the last Thursday of the month, at 14:00 UTC.
+  - [Google Calendar](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=ZDhqbDB0YjZtNmpvanJjN2Y2bWw3NnY0ajRfMjAyNTAyMjdUMTQwMDAwWiBvcGVuZWJzLnRlYW1AbQ&tmsrc=openebs.team%40gmail.com&scp=ALL)
+  - [Other Calendars](https://openebs.github.io/community/community_meeting.ics)
 - Community Meeting Recordings: [Youtube](https://www.youtube.com/@openebscommunity6021)
 
 ## Documents


### PR DESCRIPTION
Add a google calendar invite link and a generic .ics file to create calendar events.