### PR TITLE
chore: remove mhkarimi as sub-project maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -34,6 +34,5 @@ projects, sub-projects and forks contained within and under the entire OpenEBS p
 
 | Name                                                     | GitHub ID                                                   | Affiliation       | Sub-Projects      |
 |----------------------------------------------------------|-------------------------------------------------------------|-------------------|-------------------|
-| Muhammed Hussein Karimi                                  | [@mhkarimi1383](https://github.com/mhkarimi1383)            | ParminCloud       | RawFile Local PV  |
 
 <BR>


### PR DESCRIPTION
It has come to our attention that U.S. sanctions regulations restrict collaboration with individuals located in certain countries.

As such we must temporarily remove @mhkarimi1383 from the sub-project maintainer role.

For those interested in understanding the regulatory background, the Linux Foundation has published an overview here:
https://www.linuxfoundation.org/blog/navigating-global-regulations-and-open-source-us-ofac-sanctions

This action is taken solely to ensure compliance with applicable laws. It does not reflect on the individual’s contributions or standing within the community.

We hope to reinstate the role if and when the relevant restrictions are lifted.